### PR TITLE
🎨 Palette: Add accessibility labels to compact priority chips

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -25,3 +25,6 @@
 ## 2026-04-05 - Add Tooltips and Semantics to Interactive GestureDetectors
 **Learning:** When using `GestureDetector` as a custom interactive button (e.g. tapping on text to show a dialog), it inherently lacks accessibility labels and hover tooltips unlike `IconButton` or `TextButton`.
 **Action:** Always wrap interactive `GestureDetector` widgets in `Tooltip` and `Semantics(button: true)` to ensure desktop mouse users get hover feedback and screen readers correctly announce the element.
+## 2024-05-14 - Semantics and Tooltip on Compact Custom Chips
+**Learning:** Icon-only custom widgets (like compact priority chips made with InkWell) are often missed during accessibility audits compared to standard IconButtons. Adding Semantics and Tooltips to these custom elements is crucial for screen readers and desktop users.
+**Action:** Always verify if custom interactive elements built with `InkWell` or `GestureDetector` that display only icons have appropriate Semantics and Tooltip wrappers.

--- a/lib/widgets/priority_selector.dart
+++ b/lib/widgets/priority_selector.dart
@@ -28,22 +28,31 @@ class PrioritySelector extends StatelessWidget {
 
   /// Build compact chip (icon only)
   Widget _buildCompactChip(BuildContext context) {
-    return InkWell(
-      onTap: () => _showPriorityPicker(context),
-      borderRadius: BorderRadius.circular(16),
-      child: Container(
-        padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
-        decoration: BoxDecoration(
-          color: Color(priority.colorValue).withAlpha(25),
+    return Semantics(
+      label: '${priority.displayName} Priority',
+      button: true,
+      child: Tooltip(
+        message: '${priority.displayName} Priority',
+        child: InkWell(
+          onTap: () => _showPriorityPicker(context),
           borderRadius: BorderRadius.circular(16),
-          border: Border.all(
-            color: Color(priority.colorValue).withAlpha(76),
-            width: 1,
+          child: Container(
+            padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+            decoration: BoxDecoration(
+              color: Color(priority.colorValue).withAlpha(25),
+              borderRadius: BorderRadius.circular(16),
+              border: Border.all(
+                color: Color(priority.colorValue).withAlpha(76),
+                width: 1,
+              ),
+            ),
+            child: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Text(priority.icon, style: const TextStyle(fontSize: 14)),
+              ],
+            ),
           ),
-        ),
-        child: Row(
-          mainAxisSize: MainAxisSize.min,
-          children: [Text(priority.icon, style: const TextStyle(fontSize: 14))],
         ),
       ),
     );


### PR DESCRIPTION
💡 **What**: Added `Semantics` and `Tooltip` to the compact icon-only representation (`_buildCompactChip`) in `PrioritySelector`.

🎯 **Why**: Icon-only custom buttons built with `InkWell` or `GestureDetector` lack proper context for screen reader users and desktop users who hover over elements.

📸 **Before/After**: 
*Before*: The priority chip displayed an icon, but screen readers couldn't announce its meaning, and hovering did nothing.
*After*: The chip announces its meaning (e.g., "High Priority") to screen readers and shows a helpful tooltip on hover.

♿ **Accessibility**: Enhanced screen reader support and hover interactions by applying proper labels. Recorded the insight into Palette's UX journal.

---
*PR created automatically by Jules for task [16022447350156180832](https://jules.google.com/task/16022447350156180832) started by @Gameaday*