### PR TITLE
🎨 Palette: Add Tooltip and Semantics to Error Dialog InkWell

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -28,3 +28,7 @@
 ## 2024-05-14 - Semantics and Tooltip on Compact Custom Chips
 **Learning:** Icon-only custom widgets (like compact priority chips made with InkWell) are often missed during accessibility audits compared to standard IconButtons. Adding Semantics and Tooltips to these custom elements is crucial for screen readers and desktop users.
 **Action:** Always verify if custom interactive elements built with `InkWell` or `GestureDetector` that display only icons have appropriate Semantics and Tooltip wrappers.
+
+## 2024-05-18 - InkWell Interactive Elements Accessibility
+**Learning:** Adding Semantics(button: true) and a Tooltip to custom text/icon interactive elements (like an InkWell acting as an expand/collapse toggle) improves the screen reader experience by properly identifying it as a button, and provides hover feedback for desktop users.
+**Action:** When creating custom buttons using InkWell, ensure they are wrapped in Tooltip and Semantics(button: true).

--- a/lib/widgets/enhanced_error_dialog.dart
+++ b/lib/widgets/enhanced_error_dialog.dart
@@ -171,30 +171,41 @@ class _EnhancedErrorDialogState extends State<EnhancedErrorDialog> {
           // Technical details (expandable)
           if (widget.error.technicalDetails != null) ...[
             const SizedBox(height: 12),
-            InkWell(
-              onTap: () {
-                setState(() {
-                  _showTechnicalDetails = !_showTechnicalDetails;
-                });
-              },
-              child: Row(
-                children: [
-                  Icon(
-                    _showTechnicalDetails
-                        ? Icons.expand_less
-                        : Icons.expand_more,
-                    size: 20,
+            Semantics(
+              button: true,
+              label: _showTechnicalDetails
+                  ? 'Hide technical details'
+                  : 'Show technical details',
+              child: Tooltip(
+                message: _showTechnicalDetails
+                    ? 'Hide technical details'
+                    : 'Show technical details',
+                child: InkWell(
+                  onTap: () {
+                    setState(() {
+                      _showTechnicalDetails = !_showTechnicalDetails;
+                    });
+                  },
+                  child: Row(
+                    children: [
+                      Icon(
+                        _showTechnicalDetails
+                            ? Icons.expand_less
+                            : Icons.expand_more,
+                        size: 20,
+                      ),
+                      const SizedBox(width: 4),
+                      Text(
+                        _showTechnicalDetails ? 'Hide Details' : 'Show Details',
+                        style: TextStyle(
+                          fontSize: 13,
+                          color: Theme.of(context).colorScheme.onSurfaceVariant,
+                          fontWeight: FontWeight.w500,
+                        ),
+                      ),
+                    ],
                   ),
-                  const SizedBox(width: 4),
-                  Text(
-                    _showTechnicalDetails ? 'Hide Details' : 'Show Details',
-                    style: TextStyle(
-                      fontSize: 13,
-                      color: Theme.of(context).colorScheme.onSurfaceVariant,
-                      fontWeight: FontWeight.w500,
-                    ),
-                  ),
-                ],
+                ),
               ),
             ),
             if (_showTechnicalDetails) ...[


### PR DESCRIPTION
### 💡 What
Wrapped the "Show Details"/"Hide Details" `InkWell` in `lib/widgets/enhanced_error_dialog.dart` with `Semantics(button: true)` and a `Tooltip`.

### 🎯 Why
To improve accessibility. Previously, screen readers would only announce the text without identifying the element as an interactive button. Additionally, desktop users now receive a helpful tooltip on hover.

### 📸 Before/After
No major visual changes to the default view, but hovering now shows a tooltip ("Show technical details" / "Hide technical details"), and screen readers will correctly announce the element as a button.

### ♿ Accessibility
- Added `Semantics(button: true)` with an appropriate `label`.
- Added `Tooltip` for hover context.

---
*PR created automatically by Jules for task [7343166037406232176](https://jules.google.com/task/7343166037406232176) started by @Gameaday*