### PR TITLE
🎨 Palette: Add dynamic accessibility wrappers to toggleable InkWells

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -28,3 +28,7 @@
 ## 2024-05-14 - Semantics and Tooltip on Compact Custom Chips
 **Learning:** Icon-only custom widgets (like compact priority chips made with InkWell) are often missed during accessibility audits compared to standard IconButtons. Adding Semantics and Tooltips to these custom elements is crucial for screen readers and desktop users.
 **Action:** Always verify if custom interactive elements built with `InkWell` or `GestureDetector` that display only icons have appropriate Semantics and Tooltip wrappers.
+
+## 2024-04-16 - Dynamic state in accessibility wrappers
+**Learning:** For toggleable elements (like expanding folders or technical details) implemented using basic Flutter gesture recognizers (`InkWell`, `GestureDetector`), adding static tooltips and semantics labels is insufficient. Screen readers and tooltips need to reflect the *current* state of the toggle (e.g., "Expand details" vs "Collapse details").
+**Action:** Always verify if a custom button modifies local or global state, and use ternary operators or similar logic in the `Semantics.label` and `Tooltip.message` properties to dynamically describe the action the button will perform in its current state.

--- a/lib/widgets/archive_preview_widget.dart
+++ b/lib/widgets/archive_preview_widget.dart
@@ -326,33 +326,42 @@ class _ArchivePreviewWidgetState extends State<ArchivePreviewWidget> {
       children: [
         // Directory header
         if (dirPath != '.')
-          InkWell(
-            onTap: () => _toggleFolder(dirPath),
-            child: Padding(
-              padding: EdgeInsets.only(
-                left: level * 16.0 + 8,
-                top: 4,
-                bottom: 4,
-              ),
-              child: Row(
-                children: [
-                  Icon(
-                    isExpanded ? Icons.folder_open : Icons.folder,
-                    size: 20,
-                    color: Theme.of(context).colorScheme.tertiary,
+          Tooltip(
+            message: isExpanded ? 'Collapse folder' : 'Expand folder',
+            child: Semantics(
+              button: true,
+              label: isExpanded
+                  ? 'Collapse folder ${path.basename(dirPath)}'
+                  : 'Expand folder ${path.basename(dirPath)}',
+              child: InkWell(
+                onTap: () => _toggleFolder(dirPath),
+                child: Padding(
+                  padding: EdgeInsets.only(
+                    left: level * 16.0 + 8,
+                    top: 4,
+                    bottom: 4,
                   ),
-                  const SizedBox(width: 8),
-                  Expanded(
-                    child: Text(
-                      path.basename(dirPath),
-                      style: const TextStyle(fontWeight: FontWeight.bold),
-                    ),
+                  child: Row(
+                    children: [
+                      Icon(
+                        isExpanded ? Icons.folder_open : Icons.folder,
+                        size: 20,
+                        color: Theme.of(context).colorScheme.tertiary,
+                      ),
+                      const SizedBox(width: 8),
+                      Expanded(
+                        child: Text(
+                          path.basename(dirPath),
+                          style: const TextStyle(fontWeight: FontWeight.bold),
+                        ),
+                      ),
+                      Icon(
+                        isExpanded ? Icons.expand_more : Icons.chevron_right,
+                        size: 20,
+                      ),
+                    ],
                   ),
-                  Icon(
-                    isExpanded ? Icons.expand_more : Icons.chevron_right,
-                    size: 20,
-                  ),
-                ],
+                ),
               ),
             ),
           ),
@@ -378,51 +387,61 @@ class _ArchivePreviewWidgetState extends State<ArchivePreviewWidget> {
     final isSelected = _selectedFile == file;
     final filename = path.basename(file.name);
 
-    return InkWell(
-      onTap: () => _selectFile(file),
-      child: Container(
-        color: isSelected
-            ? Theme.of(context).colorScheme.primary.withValues(alpha: 0.1)
-            : null,
-        padding: EdgeInsets.only(
-          left: level * 16.0 + 8,
-          top: 8,
-          bottom: 8,
-          right: 8,
-        ),
-        child: Row(
-          children: [
-            Text(_getFileIcon(filename), style: const TextStyle(fontSize: 16)),
-            const SizedBox(width: 8),
-            Expanded(
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text(
-                    filename,
-                    style: TextStyle(
-                      fontWeight: isSelected
-                          ? FontWeight.bold
-                          : FontWeight.normal,
-                    ),
-                  ),
-                  Text(
-                    _formatFileSize(file.size),
-                    style: TextStyle(
-                      fontSize: 12,
-                      color: Theme.of(context).colorScheme.onSurfaceVariant,
-                    ),
-                  ),
-                ],
-              ),
+    return Tooltip(
+      message: 'Select $filename',
+      child: Semantics(
+        button: true,
+        label: 'Select file $filename',
+        child: InkWell(
+          onTap: () => _selectFile(file),
+          child: Container(
+            color: isSelected
+                ? Theme.of(context).colorScheme.primary.withValues(alpha: 0.1)
+                : null,
+            padding: EdgeInsets.only(
+              left: level * 16.0 + 8,
+              top: 8,
+              bottom: 8,
+              right: 8,
             ),
-            if (isSelected)
-              Icon(
-                Icons.check_circle,
-                color: Theme.of(context).colorScheme.primary,
-                size: 20,
-              ),
-          ],
+            child: Row(
+              children: [
+                Text(
+                  _getFileIcon(filename),
+                  style: const TextStyle(fontSize: 16),
+                ),
+                const SizedBox(width: 8),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        filename,
+                        style: TextStyle(
+                          fontWeight: isSelected
+                              ? FontWeight.bold
+                              : FontWeight.normal,
+                        ),
+                      ),
+                      Text(
+                        _formatFileSize(file.size),
+                        style: TextStyle(
+                          fontSize: 12,
+                          color: Theme.of(context).colorScheme.onSurfaceVariant,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+                if (isSelected)
+                  Icon(
+                    Icons.check_circle,
+                    color: Theme.of(context).colorScheme.primary,
+                    size: 20,
+                  ),
+              ],
+            ),
+          ),
         ),
       ),
     );

--- a/lib/widgets/enhanced_error_dialog.dart
+++ b/lib/widgets/enhanced_error_dialog.dart
@@ -171,30 +171,41 @@ class _EnhancedErrorDialogState extends State<EnhancedErrorDialog> {
           // Technical details (expandable)
           if (widget.error.technicalDetails != null) ...[
             const SizedBox(height: 12),
-            InkWell(
-              onTap: () {
-                setState(() {
-                  _showTechnicalDetails = !_showTechnicalDetails;
-                });
-              },
-              child: Row(
-                children: [
-                  Icon(
-                    _showTechnicalDetails
-                        ? Icons.expand_less
-                        : Icons.expand_more,
-                    size: 20,
+            Tooltip(
+              message: _showTechnicalDetails
+                  ? 'Collapse details'
+                  : 'Expand details',
+              child: Semantics(
+                button: true,
+                label: _showTechnicalDetails
+                    ? 'Collapse technical details'
+                    : 'Expand technical details',
+                child: InkWell(
+                  onTap: () {
+                    setState(() {
+                      _showTechnicalDetails = !_showTechnicalDetails;
+                    });
+                  },
+                  child: Row(
+                    children: [
+                      Icon(
+                        _showTechnicalDetails
+                            ? Icons.expand_less
+                            : Icons.expand_more,
+                        size: 20,
+                      ),
+                      const SizedBox(width: 4),
+                      Text(
+                        _showTechnicalDetails ? 'Hide Details' : 'Show Details',
+                        style: TextStyle(
+                          fontSize: 13,
+                          color: Theme.of(context).colorScheme.onSurfaceVariant,
+                          fontWeight: FontWeight.w500,
+                        ),
+                      ),
+                    ],
                   ),
-                  const SizedBox(width: 4),
-                  Text(
-                    _showTechnicalDetails ? 'Hide Details' : 'Show Details',
-                    style: TextStyle(
-                      fontSize: 13,
-                      color: Theme.of(context).colorScheme.onSurfaceVariant,
-                      fontWeight: FontWeight.w500,
-                    ),
-                  ),
-                ],
+                ),
               ),
             ),
             if (_showTechnicalDetails) ...[


### PR DESCRIPTION
💡 What: Wrapped interactive `InkWell` elements acting as custom toggle buttons with `Semantics` and `Tooltip` widgets, including dynamic labels based on their toggled state.
🎯 Why: Enhances accessibility for screen readers and improves UX for desktop/web users by providing hover context, particularly for custom expanding/collapsing elements that lack standard button semantics.
📸 Before/After: Visuals will show tooltips on hover over folder/file icons and technical details toggles.
♿ Accessibility: Screen readers will now announce "Expand technical details" or "Collapse technical details" instead of treating the toggles as generic unmarked taps.

---
*PR created automatically by Jules for task [8889759464773901418](https://jules.google.com/task/8889759464773901418) started by @Gameaday*