### PR TITLE
🎨 Palette: Add Semantics and Tooltips to InkWell components

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -28,3 +28,4 @@
 ## 2024-05-14 - Semantics and Tooltip on Compact Custom Chips
 **Learning:** Icon-only custom widgets (like compact priority chips made with InkWell) are often missed during accessibility audits compared to standard IconButtons. Adding Semantics and Tooltips to these custom elements is crucial for screen readers and desktop users.
 **Action:** Always verify if custom interactive elements built with `InkWell` or `GestureDetector` that display only icons have appropriate Semantics and Tooltip wrappers.
+## 2026-04-19 - InkWell Semantics Review\n**Learning:** When adding Semantics and Tooltips to dynamic states (like expand/collapse), dynamic text should be used based on the variable state (e.g. `isExpanded`) so that screen readers and hover tools convey accurate meaning.\n**Action:** Ensure that `label` and `message` properties in `Semantics` and `Tooltip` wrappers reflect the state directly.

--- a/lib/widgets/advanced_filters_sheet.dart
+++ b/lib/widgets/advanced_filters_sheet.dart
@@ -334,52 +334,70 @@ class _AdvancedFiltersSheetState extends State<AdvancedFiltersSheet> {
     return Card(
       elevation: 0,
       color: colorScheme.surfaceContainerHighest,
-      child: InkWell(
-        onTap: _selectDateRange,
-        borderRadius: BorderRadius.circular(12),
-        child: Padding(
-          padding: const EdgeInsets.all(16),
-          child: Row(
-            children: [
-              Icon(Icons.date_range, color: colorScheme.primary, size: 24),
-              const SizedBox(width: 16),
-              Expanded(
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Text(
-                      _selectedDateRange != null
-                          ? 'Selected Range'
-                          : 'Select Date Range',
-                      style: theme.textTheme.labelLarge?.copyWith(
-                        color: colorScheme.onSurface,
-                      ),
-                    ),
-                    if (_selectedDateRange != null) ...[
-                      const SizedBox(height: 4),
-                      Text(
-                        _selectedDateRange!.toDisplayString(),
-                        style: theme.textTheme.bodyMedium?.copyWith(
-                          color: colorScheme.onSurfaceVariant,
+      child: Semantics(
+        button: true,
+        label: _selectedDateRange != null
+            ? 'Change date range'
+            : 'Select date range',
+        child: Tooltip(
+          message: _selectedDateRange != null
+              ? 'Change date range'
+              : 'Select date range',
+          child: InkWell(
+            onTap: _selectDateRange,
+            borderRadius: BorderRadius.circular(12),
+            child: Padding(
+              padding: const EdgeInsets.all(16),
+              child: Row(
+                children: [
+                  Icon(Icons.date_range, color: colorScheme.primary, size: 24),
+                  const SizedBox(width: 16),
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          _selectedDateRange != null
+                              ? 'Selected Range'
+                              : 'Select Date Range',
+                          style: theme.textTheme.labelLarge?.copyWith(
+                            color: colorScheme.onSurface,
+                          ),
                         ),
+                        if (_selectedDateRange != null) ...[
+                          const SizedBox(height: 4),
+                          Text(
+                            _selectedDateRange!.toDisplayString(),
+                            style: theme.textTheme.bodyMedium?.copyWith(
+                              color: colorScheme.onSurfaceVariant,
+                            ),
+                          ),
+                        ],
+                      ],
+                    ),
+                  ),
+                  if (_selectedDateRange != null)
+                    IconButton(
+                      icon: Icon(
+                        Icons.clear,
+                        color: colorScheme.error,
+                        size: 20,
                       ),
-                    ],
-                  ],
-                ),
+                      onPressed: () {
+                        setState(() {
+                          _selectedDateRange = null;
+                        });
+                      },
+                      tooltip: 'Clear date range',
+                    )
+                  else
+                    Icon(
+                      Icons.chevron_right,
+                      color: colorScheme.onSurfaceVariant,
+                    ),
+                ],
               ),
-              if (_selectedDateRange != null)
-                IconButton(
-                  icon: Icon(Icons.clear, color: colorScheme.error, size: 20),
-                  onPressed: () {
-                    setState(() {
-                      _selectedDateRange = null;
-                    });
-                  },
-                  tooltip: 'Clear date range',
-                )
-              else
-                Icon(Icons.chevron_right, color: colorScheme.onSurfaceVariant),
-            ],
+            ),
           ),
         ),
       ),

--- a/lib/widgets/archive_preview_widget.dart
+++ b/lib/widgets/archive_preview_widget.dart
@@ -326,33 +326,44 @@ class _ArchivePreviewWidgetState extends State<ArchivePreviewWidget> {
       children: [
         // Directory header
         if (dirPath != '.')
-          InkWell(
-            onTap: () => _toggleFolder(dirPath),
-            child: Padding(
-              padding: EdgeInsets.only(
-                left: level * 16.0 + 8,
-                top: 4,
-                bottom: 4,
-              ),
-              child: Row(
-                children: [
-                  Icon(
-                    isExpanded ? Icons.folder_open : Icons.folder,
-                    size: 20,
-                    color: Theme.of(context).colorScheme.tertiary,
+          Semantics(
+            button: true,
+            label: isExpanded
+                ? 'Collapse folder ${path.basename(dirPath)}'
+                : 'Expand folder ${path.basename(dirPath)}',
+            child: Tooltip(
+              message: isExpanded
+                  ? 'Collapse folder ${path.basename(dirPath)}'
+                  : 'Expand folder ${path.basename(dirPath)}',
+              child: InkWell(
+                onTap: () => _toggleFolder(dirPath),
+                child: Padding(
+                  padding: EdgeInsets.only(
+                    left: level * 16.0 + 8,
+                    top: 4,
+                    bottom: 4,
                   ),
-                  const SizedBox(width: 8),
-                  Expanded(
-                    child: Text(
-                      path.basename(dirPath),
-                      style: const TextStyle(fontWeight: FontWeight.bold),
-                    ),
+                  child: Row(
+                    children: [
+                      Icon(
+                        isExpanded ? Icons.folder_open : Icons.folder,
+                        size: 20,
+                        color: Theme.of(context).colorScheme.tertiary,
+                      ),
+                      const SizedBox(width: 8),
+                      Expanded(
+                        child: Text(
+                          path.basename(dirPath),
+                          style: const TextStyle(fontWeight: FontWeight.bold),
+                        ),
+                      ),
+                      Icon(
+                        isExpanded ? Icons.expand_more : Icons.chevron_right,
+                        size: 20,
+                      ),
+                    ],
                   ),
-                  Icon(
-                    isExpanded ? Icons.expand_more : Icons.chevron_right,
-                    size: 20,
-                  ),
-                ],
+                ),
               ),
             ),
           ),
@@ -378,51 +389,61 @@ class _ArchivePreviewWidgetState extends State<ArchivePreviewWidget> {
     final isSelected = _selectedFile == file;
     final filename = path.basename(file.name);
 
-    return InkWell(
-      onTap: () => _selectFile(file),
-      child: Container(
-        color: isSelected
-            ? Theme.of(context).colorScheme.primary.withValues(alpha: 0.1)
-            : null,
-        padding: EdgeInsets.only(
-          left: level * 16.0 + 8,
-          top: 8,
-          bottom: 8,
-          right: 8,
-        ),
-        child: Row(
-          children: [
-            Text(_getFileIcon(filename), style: const TextStyle(fontSize: 16)),
-            const SizedBox(width: 8),
-            Expanded(
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text(
-                    filename,
-                    style: TextStyle(
-                      fontWeight: isSelected
-                          ? FontWeight.bold
-                          : FontWeight.normal,
-                    ),
-                  ),
-                  Text(
-                    _formatFileSize(file.size),
-                    style: TextStyle(
-                      fontSize: 12,
-                      color: Theme.of(context).colorScheme.onSurfaceVariant,
-                    ),
-                  ),
-                ],
-              ),
+    return Semantics(
+      button: true,
+      label: 'Select file $filename',
+      child: Tooltip(
+        message: 'Select file $filename',
+        child: InkWell(
+          onTap: () => _selectFile(file),
+          child: Container(
+            color: isSelected
+                ? Theme.of(context).colorScheme.primary.withValues(alpha: 0.1)
+                : null,
+            padding: EdgeInsets.only(
+              left: level * 16.0 + 8,
+              top: 8,
+              bottom: 8,
+              right: 8,
             ),
-            if (isSelected)
-              Icon(
-                Icons.check_circle,
-                color: Theme.of(context).colorScheme.primary,
-                size: 20,
-              ),
-          ],
+            child: Row(
+              children: [
+                Text(
+                  _getFileIcon(filename),
+                  style: const TextStyle(fontSize: 16),
+                ),
+                const SizedBox(width: 8),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        filename,
+                        style: TextStyle(
+                          fontWeight: isSelected
+                              ? FontWeight.bold
+                              : FontWeight.normal,
+                        ),
+                      ),
+                      Text(
+                        _formatFileSize(file.size),
+                        style: TextStyle(
+                          fontSize: 12,
+                          color: Theme.of(context).colorScheme.onSurfaceVariant,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+                if (isSelected)
+                  Icon(
+                    Icons.check_circle,
+                    color: Theme.of(context).colorScheme.primary,
+                    size: 20,
+                  ),
+              ],
+            ),
+          ),
         ),
       ),
     );


### PR DESCRIPTION
💡 What: Wrapped interactive `InkWell` components with `Semantics(button: true)` and `Tooltip` in `lib/widgets/archive_preview_widget.dart` and `lib/widgets/advanced_filters_sheet.dart`.
🎯 Why: To ensure screen readers announce these tap targets properly as buttons with descriptive actions, and to provide helpful hover feedback for mouse users.
📸 Before/After: The visual changes are tooltips appearing on hover. Screen readers now receive descriptive, dynamic announcements.
♿ Accessibility: 
- `archive_preview_widget.dart`: Directory headers now dynamically announce "Expand folder [name]" or "Collapse folder [name]". Files announce "Select file [name]".
- `advanced_filters_sheet.dart`: Date range selector announces "Select date range" or "Change date range" depending on the state.

---
*PR created automatically by Jules for task [9466775229908885090](https://jules.google.com/task/9466775229908885090) started by @Gameaday*