### PR TITLE
🎨 Palette: Add semantics and dynamic tooltips to expandable sections

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -28,3 +28,7 @@
 ## 2024-05-14 - Semantics and Tooltip on Compact Custom Chips
 **Learning:** Icon-only custom widgets (like compact priority chips made with InkWell) are often missed during accessibility audits compared to standard IconButtons. Adding Semantics and Tooltips to these custom elements is crucial for screen readers and desktop users.
 **Action:** Always verify if custom interactive elements built with `InkWell` or `GestureDetector` that display only icons have appropriate Semantics and Tooltip wrappers.
+
+## 2024-05-18 - Missing tooltips on custom accordion headers
+**Learning:** Custom expand/collapse elements built with `InkWell` often lack semantic context and hover tooltips, unlike standard Material `ExpansionTile` widgets.
+**Action:** Always wrap custom `InkWell` components acting as accordion headers (like directory trees or technical detail views) in `Semantics(button: true, expanded: isExpanded)` and a `Tooltip` with a dynamic message reflecting their state.

--- a/lib/widgets/archive_preview_widget.dart
+++ b/lib/widgets/archive_preview_widget.dart
@@ -326,33 +326,43 @@ class _ArchivePreviewWidgetState extends State<ArchivePreviewWidget> {
       children: [
         // Directory header
         if (dirPath != '.')
-          InkWell(
-            onTap: () => _toggleFolder(dirPath),
-            child: Padding(
-              padding: EdgeInsets.only(
-                left: level * 16.0 + 8,
-                top: 4,
-                bottom: 4,
-              ),
-              child: Row(
-                children: [
-                  Icon(
-                    isExpanded ? Icons.folder_open : Icons.folder,
-                    size: 20,
-                    color: Theme.of(context).colorScheme.tertiary,
+          Semantics(
+            button: true,
+            expanded: isExpanded,
+            label: isExpanded
+                ? 'Collapse folder ${path.basename(dirPath)}'
+                : 'Expand folder ${path.basename(dirPath)}',
+            child: Tooltip(
+              message: isExpanded ? 'Collapse folder' : 'Expand folder',
+              child: InkWell(
+                onTap: () => _toggleFolder(dirPath),
+                child: Padding(
+                  padding: EdgeInsets.only(
+                    left: level * 16.0 + 8,
+                    top: 4,
+                    bottom: 4,
                   ),
-                  const SizedBox(width: 8),
-                  Expanded(
-                    child: Text(
-                      path.basename(dirPath),
-                      style: const TextStyle(fontWeight: FontWeight.bold),
-                    ),
+                  child: Row(
+                    children: [
+                      Icon(
+                        isExpanded ? Icons.folder_open : Icons.folder,
+                        size: 20,
+                        color: Theme.of(context).colorScheme.tertiary,
+                      ),
+                      const SizedBox(width: 8),
+                      Expanded(
+                        child: Text(
+                          path.basename(dirPath),
+                          style: const TextStyle(fontWeight: FontWeight.bold),
+                        ),
+                      ),
+                      Icon(
+                        isExpanded ? Icons.expand_more : Icons.chevron_right,
+                        size: 20,
+                      ),
+                    ],
                   ),
-                  Icon(
-                    isExpanded ? Icons.expand_more : Icons.chevron_right,
-                    size: 20,
-                  ),
-                ],
+                ),
               ),
             ),
           ),

--- a/lib/widgets/enhanced_error_dialog.dart
+++ b/lib/widgets/enhanced_error_dialog.dart
@@ -171,30 +171,42 @@ class _EnhancedErrorDialogState extends State<EnhancedErrorDialog> {
           // Technical details (expandable)
           if (widget.error.technicalDetails != null) ...[
             const SizedBox(height: 12),
-            InkWell(
-              onTap: () {
-                setState(() {
-                  _showTechnicalDetails = !_showTechnicalDetails;
-                });
-              },
-              child: Row(
-                children: [
-                  Icon(
-                    _showTechnicalDetails
-                        ? Icons.expand_less
-                        : Icons.expand_more,
-                    size: 20,
+            Semantics(
+              button: true,
+              expanded: _showTechnicalDetails,
+              label: _showTechnicalDetails
+                  ? 'Collapse technical details'
+                  : 'Expand technical details',
+              child: Tooltip(
+                message: _showTechnicalDetails
+                    ? 'Collapse technical details'
+                    : 'Expand technical details',
+                child: InkWell(
+                  onTap: () {
+                    setState(() {
+                      _showTechnicalDetails = !_showTechnicalDetails;
+                    });
+                  },
+                  child: Row(
+                    children: [
+                      Icon(
+                        _showTechnicalDetails
+                            ? Icons.expand_less
+                            : Icons.expand_more,
+                        size: 20,
+                      ),
+                      const SizedBox(width: 4),
+                      Text(
+                        _showTechnicalDetails ? 'Hide Details' : 'Show Details',
+                        style: TextStyle(
+                          fontSize: 13,
+                          color: Theme.of(context).colorScheme.onSurfaceVariant,
+                          fontWeight: FontWeight.w500,
+                        ),
+                      ),
+                    ],
                   ),
-                  const SizedBox(width: 4),
-                  Text(
-                    _showTechnicalDetails ? 'Hide Details' : 'Show Details',
-                    style: TextStyle(
-                      fontSize: 13,
-                      color: Theme.of(context).colorScheme.onSurfaceVariant,
-                      fontWeight: FontWeight.w500,
-                    ),
-                  ),
-                ],
+                ),
               ),
             ),
             if (_showTechnicalDetails) ...[


### PR DESCRIPTION
💡 What: Added `Semantics` and `Tooltip` wrappers to custom `InkWell` widgets that function as expand/collapse headers (folder directory in `archive_preview_widget.dart` and technical details in `enhanced_error_dialog.dart`).

🎯 Why: These elements act like buttons and toggle state, but they lacked accessibility labels and hover feedback, meaning screen readers couldn't identify them or their current expanded/collapsed state.

♿ Accessibility:
- Added `Semantics(button: true, expanded: isExpanded)` to clearly announce the widget's role and state to screen readers.
- Added dynamic `label` and `Tooltip` text (e.g., "Expand folder" vs. "Collapse folder") that updates based on the widget's state.

---
*PR created automatically by Jules for task [9176224542491324408](https://jules.google.com/task/9176224542491324408) started by @Gameaday*