### PR TITLE
🎨 Palette: Add Semantics and Tooltips to interactive UI elements

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -28,3 +28,6 @@
 ## 2024-05-14 - Semantics and Tooltip on Compact Custom Chips
 **Learning:** Icon-only custom widgets (like compact priority chips made with InkWell) are often missed during accessibility audits compared to standard IconButtons. Adding Semantics and Tooltips to these custom elements is crucial for screen readers and desktop users.
 **Action:** Always verify if custom interactive elements built with `InkWell` or `GestureDetector` that display only icons have appropriate Semantics and Tooltip wrappers.
+## 2026-05-05 - Semantics for expanding/collapsing UI
+**Learning:** Expanding/collapsing sections built with InkWell require dynamic labels to accurately reflect their state to screen readers (e.g. 'Show details' vs 'Hide details').
+**Action:** Always wrap these widgets with Semantics and Tooltip, and update their string values based on the current toggle state.

--- a/lib/widgets/archive_preview_widget.dart
+++ b/lib/widgets/archive_preview_widget.dart
@@ -326,33 +326,42 @@ class _ArchivePreviewWidgetState extends State<ArchivePreviewWidget> {
       children: [
         // Directory header
         if (dirPath != '.')
-          InkWell(
-            onTap: () => _toggleFolder(dirPath),
-            child: Padding(
-              padding: EdgeInsets.only(
-                left: level * 16.0 + 8,
-                top: 4,
-                bottom: 4,
-              ),
-              child: Row(
-                children: [
-                  Icon(
-                    isExpanded ? Icons.folder_open : Icons.folder,
-                    size: 20,
-                    color: Theme.of(context).colorScheme.tertiary,
+          Semantics(
+            button: true,
+            label: isExpanded
+                ? 'Collapse folder ${path.basename(dirPath)}'
+                : 'Expand folder ${path.basename(dirPath)}',
+            child: Tooltip(
+              message: isExpanded ? 'Collapse folder' : 'Expand folder',
+              child: InkWell(
+                onTap: () => _toggleFolder(dirPath),
+                child: Padding(
+                  padding: EdgeInsets.only(
+                    left: level * 16.0 + 8,
+                    top: 4,
+                    bottom: 4,
                   ),
-                  const SizedBox(width: 8),
-                  Expanded(
-                    child: Text(
-                      path.basename(dirPath),
-                      style: const TextStyle(fontWeight: FontWeight.bold),
-                    ),
+                  child: Row(
+                    children: [
+                      Icon(
+                        isExpanded ? Icons.folder_open : Icons.folder,
+                        size: 20,
+                        color: Theme.of(context).colorScheme.tertiary,
+                      ),
+                      const SizedBox(width: 8),
+                      Expanded(
+                        child: Text(
+                          path.basename(dirPath),
+                          style: const TextStyle(fontWeight: FontWeight.bold),
+                        ),
+                      ),
+                      Icon(
+                        isExpanded ? Icons.expand_more : Icons.chevron_right,
+                        size: 20,
+                      ),
+                    ],
                   ),
-                  Icon(
-                    isExpanded ? Icons.expand_more : Icons.chevron_right,
-                    size: 20,
-                  ),
-                ],
+                ),
               ),
             ),
           ),
@@ -378,51 +387,61 @@ class _ArchivePreviewWidgetState extends State<ArchivePreviewWidget> {
     final isSelected = _selectedFile == file;
     final filename = path.basename(file.name);
 
-    return InkWell(
-      onTap: () => _selectFile(file),
-      child: Container(
-        color: isSelected
-            ? Theme.of(context).colorScheme.primary.withValues(alpha: 0.1)
-            : null,
-        padding: EdgeInsets.only(
-          left: level * 16.0 + 8,
-          top: 8,
-          bottom: 8,
-          right: 8,
-        ),
-        child: Row(
-          children: [
-            Text(_getFileIcon(filename), style: const TextStyle(fontSize: 16)),
-            const SizedBox(width: 8),
-            Expanded(
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text(
-                    filename,
-                    style: TextStyle(
-                      fontWeight: isSelected
-                          ? FontWeight.bold
-                          : FontWeight.normal,
-                    ),
-                  ),
-                  Text(
-                    _formatFileSize(file.size),
-                    style: TextStyle(
-                      fontSize: 12,
-                      color: Theme.of(context).colorScheme.onSurfaceVariant,
-                    ),
-                  ),
-                ],
-              ),
+    return Semantics(
+      button: true,
+      label: 'Select file $filename',
+      child: Tooltip(
+        message: 'View file',
+        child: InkWell(
+          onTap: () => _selectFile(file),
+          child: Container(
+            color: isSelected
+                ? Theme.of(context).colorScheme.primary.withValues(alpha: 0.1)
+                : null,
+            padding: EdgeInsets.only(
+              left: level * 16.0 + 8,
+              top: 8,
+              bottom: 8,
+              right: 8,
             ),
-            if (isSelected)
-              Icon(
-                Icons.check_circle,
-                color: Theme.of(context).colorScheme.primary,
-                size: 20,
-              ),
-          ],
+            child: Row(
+              children: [
+                Text(
+                  _getFileIcon(filename),
+                  style: const TextStyle(fontSize: 16),
+                ),
+                const SizedBox(width: 8),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        filename,
+                        style: TextStyle(
+                          fontWeight: isSelected
+                              ? FontWeight.bold
+                              : FontWeight.normal,
+                        ),
+                      ),
+                      Text(
+                        _formatFileSize(file.size),
+                        style: TextStyle(
+                          fontSize: 12,
+                          color: Theme.of(context).colorScheme.onSurfaceVariant,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+                if (isSelected)
+                  Icon(
+                    Icons.check_circle,
+                    color: Theme.of(context).colorScheme.primary,
+                    size: 20,
+                  ),
+              ],
+            ),
+          ),
         ),
       ),
     );

--- a/lib/widgets/enhanced_error_dialog.dart
+++ b/lib/widgets/enhanced_error_dialog.dart
@@ -171,30 +171,41 @@ class _EnhancedErrorDialogState extends State<EnhancedErrorDialog> {
           // Technical details (expandable)
           if (widget.error.technicalDetails != null) ...[
             const SizedBox(height: 12),
-            InkWell(
-              onTap: () {
-                setState(() {
-                  _showTechnicalDetails = !_showTechnicalDetails;
-                });
-              },
-              child: Row(
-                children: [
-                  Icon(
-                    _showTechnicalDetails
-                        ? Icons.expand_less
-                        : Icons.expand_more,
-                    size: 20,
+            Semantics(
+              button: true,
+              label: _showTechnicalDetails
+                  ? 'Hide technical details'
+                  : 'Show technical details',
+              child: Tooltip(
+                message: _showTechnicalDetails
+                    ? 'Hide technical details'
+                    : 'Show technical details',
+                child: InkWell(
+                  onTap: () {
+                    setState(() {
+                      _showTechnicalDetails = !_showTechnicalDetails;
+                    });
+                  },
+                  child: Row(
+                    children: [
+                      Icon(
+                        _showTechnicalDetails
+                            ? Icons.expand_less
+                            : Icons.expand_more,
+                        size: 20,
+                      ),
+                      const SizedBox(width: 4),
+                      Text(
+                        _showTechnicalDetails ? 'Hide Details' : 'Show Details',
+                        style: TextStyle(
+                          fontSize: 13,
+                          color: Theme.of(context).colorScheme.onSurfaceVariant,
+                          fontWeight: FontWeight.w500,
+                        ),
+                      ),
+                    ],
                   ),
-                  const SizedBox(width: 4),
-                  Text(
-                    _showTechnicalDetails ? 'Hide Details' : 'Show Details',
-                    style: TextStyle(
-                      fontSize: 13,
-                      color: Theme.of(context).colorScheme.onSurfaceVariant,
-                      fontWeight: FontWeight.w500,
-                    ),
-                  ),
-                ],
+                ),
               ),
             ),
             if (_showTechnicalDetails) ...[


### PR DESCRIPTION
💡 What: Added `Semantics` and `Tooltip` widgets wrapping custom interactive `InkWell` components used for file selection and expanding/collapsing sections in `archive_preview_widget` and `enhanced_error_dialog`.

🎯 Why: These `InkWell` elements act as custom buttons but were missing critical accessibility attributes. Without `Semantics`, screen readers struggle to convey their purpose, and without `Tooltips`, desktop/web users lacked clear hover context.

♿ Accessibility:
- Dynamic labels added for expanding/collapsing folders (e.g., "Expand folder" vs "Collapse folder").
- Clear semantic labels for file selection ("Select file [filename]").
- Clear semantic labels for technical details toggle ("Show technical details" vs "Hide technical details").

---
*PR created automatically by Jules for task [2932536188679246152](https://jules.google.com/task/2932536188679246152) started by @Gameaday*