### PR TITLE
🎨 Palette: Improve accessibility of date range selector in Advanced Filters

### DIFF
--- a/lib/widgets/advanced_filters_sheet.dart
+++ b/lib/widgets/advanced_filters_sheet.dart
@@ -334,52 +334,68 @@ class _AdvancedFiltersSheetState extends State<AdvancedFiltersSheet> {
     return Card(
       elevation: 0,
       color: colorScheme.surfaceContainerHighest,
-      child: InkWell(
-        onTap: _selectDateRange,
-        borderRadius: BorderRadius.circular(12),
-        child: Padding(
-          padding: const EdgeInsets.all(16),
-          child: Row(
-            children: [
-              Icon(Icons.date_range, color: colorScheme.primary, size: 24),
-              const SizedBox(width: 16),
-              Expanded(
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Text(
-                      _selectedDateRange != null
-                          ? 'Selected Range'
-                          : 'Select Date Range',
-                      style: theme.textTheme.labelLarge?.copyWith(
-                        color: colorScheme.onSurface,
-                      ),
-                    ),
-                    if (_selectedDateRange != null) ...[
-                      const SizedBox(height: 4),
-                      Text(
-                        _selectedDateRange!.toDisplayString(),
-                        style: theme.textTheme.bodyMedium?.copyWith(
-                          color: colorScheme.onSurfaceVariant,
+      child: Semantics(
+        label: _selectedDateRange != null
+            ? 'Selected date range: ${_selectedDateRange!.toDisplayString()}'
+            : 'Select Date Range',
+        button: true,
+        child: Tooltip(
+          message: 'Select Date Range',
+          child: InkWell(
+            onTap: _selectDateRange,
+            borderRadius: BorderRadius.circular(12),
+            child: Padding(
+              padding: const EdgeInsets.all(16),
+              child: Row(
+                children: [
+                  Icon(Icons.date_range, color: colorScheme.primary, size: 24),
+                  const SizedBox(width: 16),
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          _selectedDateRange != null
+                              ? 'Selected Range'
+                              : 'Select Date Range',
+                          style: theme.textTheme.labelLarge?.copyWith(
+                            color: colorScheme.onSurface,
+                          ),
                         ),
+                        if (_selectedDateRange != null) ...[
+                          const SizedBox(height: 4),
+                          Text(
+                            _selectedDateRange!.toDisplayString(),
+                            style: theme.textTheme.bodyMedium?.copyWith(
+                              color: colorScheme.onSurfaceVariant,
+                            ),
+                          ),
+                        ],
+                      ],
+                    ),
+                  ),
+                  if (_selectedDateRange != null)
+                    IconButton(
+                      icon: Icon(
+                        Icons.clear,
+                        color: colorScheme.error,
+                        size: 20,
                       ),
-                    ],
-                  ],
-                ),
+                      onPressed: () {
+                        setState(() {
+                          _selectedDateRange = null;
+                        });
+                      },
+                      tooltip: 'Clear date range',
+                    )
+                  else
+                    Icon(
+                      Icons.chevron_right,
+                      color: colorScheme.onSurfaceVariant,
+                    ),
+                ],
               ),
-              if (_selectedDateRange != null)
-                IconButton(
-                  icon: Icon(Icons.clear, color: colorScheme.error, size: 20),
-                  onPressed: () {
-                    setState(() {
-                      _selectedDateRange = null;
-                    });
-                  },
-                  tooltip: 'Clear date range',
-                )
-              else
-                Icon(Icons.chevron_right, color: colorScheme.onSurfaceVariant),
-            ],
+            ),
           ),
         ),
       ),


### PR DESCRIPTION
💡 What: Added `Semantics` and `Tooltip` to the interactive date range selector in the Advanced Filters sheet.
🎯 Why: Custom interactive elements built with `InkWell` (like this date range selector card) inherently lack accessibility labels and hover tooltips. Adding these wrappers ensures the element is accessible to screen readers (announced as a button with its current value) and provides hover feedback for desktop users.
♿ Accessibility: Added `Semantics(button: true, label: ...)` to announce the current selected date range to screen readers, and `Tooltip(message: 'Select Date Range')` for hover context.

---
*PR created automatically by Jules for task [16251340115611611909](https://jules.google.com/task/16251340115611611909) started by @Gameaday*