### PR TITLE
🎨 Palette: Add hover tooltips to archive result cards

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -45,3 +45,7 @@
 ## 2026-05-15 - Semantics Wrapper Placement
 **Learning:** When making a Flutter Card widget actionable via an internal InkWell, the Semantics wrapper must be placed *outside* the Card. If placed inside, screen readers may not correctly identify the entire card bounds as the interactive element.
 **Action:** Always wrap the outermost Container/Card with Semantics instead of the internal InkWell.
+
+## 2025-01-23 - Added tooltips to Card InkWells
+**Learning:** When a Flutter Card uses an internal InkWell, adding Tooltip outside the Card works but inside the Card on the InkWell is also possible. The memory instruction says to put the Semantics outside the Card, and Tooltip inside Semantics.
+**Action:** Wrapped Card with Tooltip to provide hover labels for interactive Cards.

--- a/lib/widgets/archive_result_card.dart
+++ b/lib/widgets/archive_result_card.dart
@@ -46,133 +46,30 @@ class ArchiveResultCard extends StatelessWidget {
       label: _buildSemanticLabel(),
       button: true,
       enabled: true,
-      child: Card(
-        clipBehavior: Clip.antiAlias,
-        elevation: 1,
-        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
-        child: InkWell(
-          onTap: onTap,
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              // Thumbnail section with Hero animation
-              Hero(
-                tag: 'archive-thumbnail-${result.identifier}',
-                child: AspectRatio(
-                  aspectRatio: _getAspectRatio(),
-                  child: _buildThumbnail(context),
-                ),
-              ),
-
-              // Content section
-              Padding(
-                padding: const EdgeInsets.all(12),
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    // Title
-                    Text(
-                      result.title,
-                      style: textTheme.titleSmall?.copyWith(
-                        fontWeight: FontWeight.w600,
-                        height: 1.3,
-                      ),
-                      maxLines: 2,
-                      overflow: TextOverflow.ellipsis,
-                    ),
-
-                    // Creator (if available)
-                    if (result.creator != null &&
-                        result.creator!.isNotEmpty) ...[
-                      const SizedBox(height: 4),
-                      Text(
-                        result.creator!,
-                        style: textTheme.bodySmall?.copyWith(
-                          color: colorScheme.onSurfaceVariant,
-                        ),
-                        maxLines: 1,
-                        overflow: TextOverflow.ellipsis,
-                      ),
-                    ],
-
-                    const SizedBox(height: 8),
-
-                    // Metadata chips
-                    Wrap(
-                      spacing: 4,
-                      runSpacing: 4,
-                      children: [
-                        if (result.mediaType != null)
-                          _buildMetadataChip(
-                            context,
-                            _formatMediaType(result.mediaType!),
-                            Icons.category_outlined,
-                          ),
-                        if (result.downloads != null && result.downloads! > 0)
-                          _buildMetadataChip(
-                            context,
-                            _formatDownloads(result.downloads!),
-                            Icons.download_outlined,
-                          ),
-                        if (result.date != null)
-                          _buildMetadataChip(
-                            context,
-                            _formatDate(result.date!),
-                            Icons.calendar_today_outlined,
-                          ),
-                      ],
-                    ),
-
-                    // Favorite button
-                    Align(
-                      alignment: Alignment.centerRight,
-                      child: FavoriteIconButton(
-                        identifier: result.identifier,
-                        iconSize: 18,
-                      ),
-                    ),
-                  ],
-                ),
-              ),
-            ],
+      child: Tooltip(
+        message: 'View ${result.title}',
+        child: Card(
+          clipBehavior: Clip.antiAlias,
+          elevation: 1,
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(12),
           ),
-        ),
-      ),
-    );
-  }
-
-  /// Build list layout card (thumbnail on left)
-  Widget _buildListCard(BuildContext context) {
-    final colorScheme = Theme.of(context).colorScheme;
-    final textTheme = Theme.of(context).textTheme;
-
-    return Semantics(
-      label: _buildSemanticLabel(),
-      button: true,
-      enabled: true,
-      child: Card(
-        clipBehavior: Clip.antiAlias,
-        elevation: 1,
-        margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
-        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
-        child: InkWell(
-          onTap: onTap,
-          child: Row(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              // Thumbnail section with Hero animation
-              Hero(
-                tag: 'archive-thumbnail-${result.identifier}',
-                child: SizedBox(
-                  width: 120,
-                  height: 120,
-                  child: _buildThumbnail(context),
+          child: InkWell(
+            onTap: onTap,
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                // Thumbnail section with Hero animation
+                Hero(
+                  tag: 'archive-thumbnail-${result.identifier}',
+                  child: AspectRatio(
+                    aspectRatio: _getAspectRatio(),
+                    child: _buildThumbnail(context),
+                  ),
                 ),
-              ),
 
-              // Content section
-              Expanded(
-                child: Padding(
+                // Content section
+                Padding(
                   padding: const EdgeInsets.all(12),
                   child: Column(
                     crossAxisAlignment: CrossAxisAlignment.start,
@@ -198,19 +95,6 @@ class ArchiveResultCard extends StatelessWidget {
                             color: colorScheme.onSurfaceVariant,
                           ),
                           maxLines: 1,
-                          overflow: TextOverflow.ellipsis,
-                        ),
-                      ],
-
-                      // Description (if available)
-                      if (result.description.isNotEmpty) ...[
-                        const SizedBox(height: 6),
-                        Text(
-                          result.description,
-                          style: textTheme.bodySmall?.copyWith(
-                            color: colorScheme.onSurface.withValues(alpha: 0.7),
-                          ),
-                          maxLines: 2,
                           overflow: TextOverflow.ellipsis,
                         ),
                       ],
@@ -242,20 +126,149 @@ class ArchiveResultCard extends StatelessWidget {
                             ),
                         ],
                       ),
+
+                      // Favorite button
+                      Align(
+                        alignment: Alignment.centerRight,
+                        child: FavoriteIconButton(
+                          identifier: result.identifier,
+                          iconSize: 18,
+                        ),
+                      ),
                     ],
                   ),
                 ),
-              ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
 
-              // Favorite button
-              Padding(
-                padding: const EdgeInsets.all(8),
-                child: FavoriteIconButton(
-                  identifier: result.identifier,
-                  iconSize: 18,
+  /// Build list layout card (thumbnail on left)
+  Widget _buildListCard(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final textTheme = Theme.of(context).textTheme;
+
+    return Semantics(
+      label: _buildSemanticLabel(),
+      button: true,
+      enabled: true,
+      child: Tooltip(
+        message: 'View ${result.title}',
+        child: Card(
+          clipBehavior: Clip.antiAlias,
+          elevation: 1,
+          margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(12),
+          ),
+          child: InkWell(
+            onTap: onTap,
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                // Thumbnail section with Hero animation
+                Hero(
+                  tag: 'archive-thumbnail-${result.identifier}',
+                  child: SizedBox(
+                    width: 120,
+                    height: 120,
+                    child: _buildThumbnail(context),
+                  ),
                 ),
-              ),
-            ],
+
+                // Content section
+                Expanded(
+                  child: Padding(
+                    padding: const EdgeInsets.all(12),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        // Title
+                        Text(
+                          result.title,
+                          style: textTheme.titleSmall?.copyWith(
+                            fontWeight: FontWeight.w600,
+                            height: 1.3,
+                          ),
+                          maxLines: 2,
+                          overflow: TextOverflow.ellipsis,
+                        ),
+
+                        // Creator (if available)
+                        if (result.creator != null &&
+                            result.creator!.isNotEmpty) ...[
+                          const SizedBox(height: 4),
+                          Text(
+                            result.creator!,
+                            style: textTheme.bodySmall?.copyWith(
+                              color: colorScheme.onSurfaceVariant,
+                            ),
+                            maxLines: 1,
+                            overflow: TextOverflow.ellipsis,
+                          ),
+                        ],
+
+                        // Description (if available)
+                        if (result.description.isNotEmpty) ...[
+                          const SizedBox(height: 6),
+                          Text(
+                            result.description,
+                            style: textTheme.bodySmall?.copyWith(
+                              color: colorScheme.onSurface.withValues(
+                                alpha: 0.7,
+                              ),
+                            ),
+                            maxLines: 2,
+                            overflow: TextOverflow.ellipsis,
+                          ),
+                        ],
+
+                        const SizedBox(height: 8),
+
+                        // Metadata chips
+                        Wrap(
+                          spacing: 4,
+                          runSpacing: 4,
+                          children: [
+                            if (result.mediaType != null)
+                              _buildMetadataChip(
+                                context,
+                                _formatMediaType(result.mediaType!),
+                                Icons.category_outlined,
+                              ),
+                            if (result.downloads != null &&
+                                result.downloads! > 0)
+                              _buildMetadataChip(
+                                context,
+                                _formatDownloads(result.downloads!),
+                                Icons.download_outlined,
+                              ),
+                            if (result.date != null)
+                              _buildMetadataChip(
+                                context,
+                                _formatDate(result.date!),
+                                Icons.calendar_today_outlined,
+                              ),
+                          ],
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+
+                // Favorite button
+                Padding(
+                  padding: const EdgeInsets.all(8),
+                  child: FavoriteIconButton(
+                    identifier: result.identifier,
+                    iconSize: 18,
+                  ),
+                ),
+              ],
+            ),
           ),
         ),
       ),


### PR DESCRIPTION
**💡 What:** Added `Tooltip` wrappers around the interactive `Card` components within `ArchiveResultCard` (both list and grid layouts). Also ensured that the `.Jules/palette.md` log correctly tracks the learning.

**🎯 Why:** The `ArchiveResultCard` is an interactive element (acting as a button via `InkWell`). While it had `Semantics` for screen readers, it lacked visual hover/long-press feedback explaining what clicking it does. The new tooltips show "View [Title]", giving helpful context, especially since the title text might be truncated due to `maxLines`.

**📸 Before/After:**
*   **Before:** Hovering over an archive result card showed no tooltip.
*   **After:** Hovering over an archive result card shows a tooltip with the full title: "View [Title]".

**♿ Accessibility:**
*   Provides clear, visible labels for hover interactions (desktop).
*   Allows mobile users to long-press the card to read the full title if truncated.
*   Retains the existing robust screen reader support via the outer `Semantics` wrapper.

---
*PR created automatically by Jules for task [5854594567545598179](https://jules.google.com/task/5854594567545598179) started by @Gameaday*