### PR TITLE
🎨 Palette: Add Semantics to search history items

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -49,3 +49,7 @@
 ## 2025-01-23 - Added tooltips to Card InkWells
 **Learning:** When a Flutter Card uses an internal InkWell, adding Tooltip outside the Card works but inside the Card on the InkWell is also possible. The memory instruction says to put the Semantics outside the Card, and Tooltip inside Semantics.
 **Action:** Wrapped Card with Tooltip to provide hover labels for interactive Cards.
+
+## 2024-05-19 - Adding Semantics to Interactive List Items
+**Learning:** `InkWell` or `GestureDetector` widgets used for interactive items within lists (such as search history entries) are not implicitly recognized as buttons by screen readers. This makes navigation confusing for users relying on accessibility tools.
+**Action:** Always wrap interactive list items (`InkWell`, `GestureDetector`) with a `Semantics` widget, setting `button: true` and providing a descriptive `label` (e.g., `'Search history: ${entry.title}'`) to ensure they are properly identified as actionable controls.

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -340,49 +340,55 @@ class _HomeScreenState extends State<HomeScreen> {
                           color: Theme.of(context).colorScheme.onError,
                         ),
                       ),
-                      child: InkWell(
-                        onTap: () => _handleSearch(
-                          entry.identifier,
-                          SearchType.identifier,
-                        ),
-                        borderRadius: BorderRadius.circular(8),
-                        child: Container(
-                          padding: const EdgeInsets.symmetric(
-                            horizontal: 16,
-                            vertical: 12,
+                      child: Semantics(
+                        button: true,
+                        label: 'Search history: ${entry.title}',
+                        child: InkWell(
+                          onTap: () => _handleSearch(
+                            entry.identifier,
+                            SearchType.identifier,
                           ),
-                          decoration: BoxDecoration(
-                            color: Theme.of(
-                              context,
-                            ).colorScheme.surfaceContainerHighest,
-                            borderRadius: BorderRadius.circular(8),
-                          ),
-                          child: Row(
-                            children: [
-                              Icon(
-                                Icons.history,
-                                size: 20,
-                                color: Theme.of(
-                                  context,
-                                ).colorScheme.onSurfaceVariant,
-                              ),
-                              const SizedBox(width: 12),
-                              Expanded(
-                                child: Text(
-                                  entry.title,
-                                  maxLines: 1,
-                                  overflow: TextOverflow.ellipsis,
-                                  style: Theme.of(context).textTheme.bodyMedium,
+                          borderRadius: BorderRadius.circular(8),
+                          child: Container(
+                            padding: const EdgeInsets.symmetric(
+                              horizontal: 16,
+                              vertical: 12,
+                            ),
+                            decoration: BoxDecoration(
+                              color: Theme.of(
+                                context,
+                              ).colorScheme.surfaceContainerHighest,
+                              borderRadius: BorderRadius.circular(8),
+                            ),
+                            child: Row(
+                              children: [
+                                Icon(
+                                  Icons.history,
+                                  size: 20,
+                                  color: Theme.of(
+                                    context,
+                                  ).colorScheme.onSurfaceVariant,
                                 ),
-                              ),
-                              Icon(
-                                Icons.arrow_forward_ios,
-                                size: 16,
-                                color: Theme.of(
-                                  context,
-                                ).colorScheme.onSurfaceVariant,
-                              ),
-                            ],
+                                const SizedBox(width: 12),
+                                Expanded(
+                                  child: Text(
+                                    entry.title,
+                                    maxLines: 1,
+                                    overflow: TextOverflow.ellipsis,
+                                    style: Theme.of(
+                                      context,
+                                    ).textTheme.bodyMedium,
+                                  ),
+                                ),
+                                Icon(
+                                  Icons.arrow_forward_ios,
+                                  size: 16,
+                                  color: Theme.of(
+                                    context,
+                                  ).colorScheme.onSurfaceVariant,
+                                ),
+                              ],
+                            ),
                           ),
                         ),
                       ),


### PR DESCRIPTION
💡 **What:** Added a `Semantics` widget around the `InkWell` used for search history entries in `lib/screens/home_screen.dart`.
🎯 **Why:** To ensure that screen readers accurately announce the history entries as interactive buttons, improving navigation for visually impaired users. Previously, the `InkWell` within the `Dismissible` item was opaque to screen readers.
♿ **Accessibility:** Added `Semantics(button: true, label: 'Search history: ${entry.title}')` to provide clear, actionable context to assistive technologies.

---
*PR created automatically by Jules for task [10301118281294723138](https://jules.google.com/task/10301118281294723138) started by @Gameaday*