### PR TITLE
🎨 Palette: Add tooltip to favorite cards

### DIFF
--- a/lib/screens/favorites_screen.dart
+++ b/lib/screens/favorites_screen.dart
@@ -404,10 +404,13 @@ class _FavoritesScreenState extends State<FavoritesScreen> {
               Positioned(
                 top: 8,
                 right: 8,
-                child: FavoriteIconButton(
-                  identifier: favorite.identifier,
-                  onFavoriteChanged: (_) =>
-                      _onFavoriteRemoved(favorite.identifier),
+                child: Tooltip(
+                  message: 'Remove ${favorite.displayTitle} from favorites',
+                  child: FavoriteIconButton(
+                    identifier: favorite.identifier,
+                    onFavoriteChanged: (_) =>
+                        _onFavoriteRemoved(favorite.identifier),
+                  ),
                 ),
               ),
             ],
@@ -458,9 +461,12 @@ class _FavoritesScreenState extends State<FavoritesScreen> {
             ),
           ],
         ),
-        trailing: FavoriteIconButton(
-          identifier: favorite.identifier,
-          onFavoriteChanged: (_) => _onFavoriteRemoved(favorite.identifier),
+        trailing: Tooltip(
+          message: 'Remove ${favorite.displayTitle} from favorites',
+          child: FavoriteIconButton(
+            identifier: favorite.identifier,
+            onFavoriteChanged: (_) => _onFavoriteRemoved(favorite.identifier),
+          ),
         ),
         onTap: () => _navigateToDetail(favorite),
       ),


### PR DESCRIPTION
💡 What: Added a `Tooltip` widget around the `FavoriteIconButton` inside `_buildGridItem` and `_buildListItem` in `lib/screens/favorites_screen.dart` (and subsequently removed the duplicate PR artifact to fix the build).

🎯 Why: To improve accessibility. Tooltips explicitly communicate the state changes to desktop users (via hover) and screen readers, helping them understand what an icon-only button like a heart/star does without needing to click it.

📸 Before/After: Visuals will show a simple material hover tooltip reading "Remove [Title] from favorites".

♿ Accessibility: Ensures that screen reader users and those navigating by keyboard/mouse hover have context for the `FavoriteIconButton`.

---
*PR created automatically by Jules for task [3586972640886363127](https://jules.google.com/task/3586972640886363127) started by @Gameaday*