### PR TITLE
🎨 Palette: Add accessibility wrapper to More Screen menu items

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -60,3 +60,7 @@
 ## 2026-05-20 - Added Tooltip to Card Widgets
 **Learning:** When using internal InkWell or GestureDetector inside a Card widget, wrapping the inner widget with Tooltip doesn't properly provide hover context or accessibility support to the boundaries of the Card. Applying the Tooltip wrapper outside the Card (but inside Semantics) ensures that the hover bounding box and screen reader behavior properly applies to the entire visual Card surface area.
 **Action:** Always wrap Card widgets in Tooltip when they contain interactive elements like InkWell to provide a smooth desktop hover and screen reader experience.
+
+## 2026-05-26 - Semantics Wrapper in Grid Card
+**Learning:** In Flutter, when wrapping a `Card` containing an `InkWell` for accessibility, apply the `Semantics` wrapper to the parent `Card` widget, not the child, to prevent confusing screen reader announcements.
+**Action:** When wrapping a `Card` containing an `InkWell` for accessibility, apply the `Semantics(button: true)` wrapper to the parent `Card` widget.

--- a/lib/screens/more_screen.dart
+++ b/lib/screens/more_screen.dart
@@ -592,56 +592,63 @@ class _MenuItemCard extends StatelessWidget {
     final theme = Theme.of(context);
     final colorScheme = theme.colorScheme;
 
-    return Card(
-      clipBehavior: Clip.antiAlias,
-      child: InkWell(
-        onTap: onTap,
-        child: Padding(
-          padding: const EdgeInsets.all(16.0),
-          child: Row(
-            children: [
-              Container(
-                width: 40,
-                height: 40,
-                decoration: BoxDecoration(
-                  color: colorScheme.primaryContainer,
-                  borderRadius: BorderRadius.circular(12),
-                ),
-                child: Icon(
-                  icon,
-                  size: 24,
-                  color: colorScheme.onPrimaryContainer,
-                ),
-              ),
-              const SizedBox(width: 16),
-              Expanded(
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  mainAxisAlignment: MainAxisAlignment.center,
-                  children: [
-                    Text(
-                      title,
-                      style: theme.textTheme.titleSmall?.copyWith(
-                        fontWeight: FontWeight.w600,
-                      ),
-                      maxLines: 1,
-                      overflow: TextOverflow.ellipsis,
+    return Semantics(
+      button: true,
+      label: '$title: $subtitle',
+      child: Tooltip(
+        message: 'Open $title',
+        child: Card(
+          clipBehavior: Clip.antiAlias,
+          child: InkWell(
+            onTap: onTap,
+            child: Padding(
+              padding: const EdgeInsets.all(16.0),
+              child: Row(
+                children: [
+                  Container(
+                    width: 40,
+                    height: 40,
+                    decoration: BoxDecoration(
+                      color: colorScheme.primaryContainer,
+                      borderRadius: BorderRadius.circular(12),
                     ),
-                    const SizedBox(height: 2),
-                    Text(
-                      subtitle,
-                      style: theme.textTheme.bodySmall?.copyWith(
-                        color: colorScheme.onSurfaceVariant,
-                      ),
-                      maxLines: 1,
-                      overflow: TextOverflow.ellipsis,
+                    child: Icon(
+                      icon,
+                      size: 24,
+                      color: colorScheme.onPrimaryContainer,
                     ),
-                  ],
-                ),
+                  ),
+                  const SizedBox(width: 16),
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      children: [
+                        Text(
+                          title,
+                          style: theme.textTheme.titleSmall?.copyWith(
+                            fontWeight: FontWeight.w600,
+                          ),
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                        const SizedBox(height: 2),
+                        Text(
+                          subtitle,
+                          style: theme.textTheme.bodySmall?.copyWith(
+                            color: colorScheme.onSurfaceVariant,
+                          ),
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                      ],
+                    ),
+                  ),
+                  const SizedBox(width: 8),
+                  Icon(Icons.chevron_right, color: colorScheme.outline),
+                ],
               ),
-              const SizedBox(width: 8),
-              Icon(Icons.chevron_right, color: colorScheme.outline),
-            ],
+            ),
           ),
         ),
       ),


### PR DESCRIPTION
**What:** Added `Semantics` (`button: true`) and `Tooltip` to the `_MenuItemCard` widget in `lib/screens/more_screen.dart`.
**Why:** The menu items lacked proper screen reader labels and desktop hover context, making them less accessible for visually impaired users and less intuitive for desktop users.
**Accessibility:** Screen readers now announce the item as a button along with its title and subtitle. Desktop users get a helpful tooltip on hover.

---
*PR created automatically by Jules for task [11358697928649699423](https://jules.google.com/task/11358697928649699423) started by @Gameaday*