### PR TITLE
🎨 Palette: Add missing Tooltip to full Priority Selector chip

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -64,3 +64,6 @@
 ## 2026-05-26 - Semantics Wrapper in Grid Card
 **Learning:** In Flutter, when wrapping a `Card` containing an `InkWell` for accessibility, apply the `Semantics` wrapper to the parent `Card` widget, not the child, to prevent confusing screen reader announcements.
 **Action:** When wrapping a `Card` containing an `InkWell` for accessibility, apply the `Semantics(button: true)` wrapper to the parent `Card` widget.
+## 2025-05-19 - Added missing Tooltip to Priority Selector Full Chip
+**Learning:** Even when custom widgets (like the priority chip using `InkWell`) have proper `Semantics` wrappers, they often lack `Tooltip` wrappers. This creates an inconsistent experience where screen reader users get proper context, but desktop/web users using a mouse get no hover tooltip indicating the element is interactive and what it does.
+**Action:** When adding accessibility to custom interactive components, always ensure that both `Semantics` (for screen readers) and `Tooltip` (for visual hover context) are implemented, and remember to use `excludeFromSemantics: true` on the `Tooltip` to prevent duplicate announcements.

--- a/lib/widgets/priority_selector.dart
+++ b/lib/widgets/priority_selector.dart
@@ -63,33 +63,37 @@ class PrioritySelector extends StatelessWidget {
     return Semantics(
       button: true,
       label: 'Change priority. Current priority: ${priority.displayName}',
-      child: InkWell(
-        onTap: () => _showPriorityPicker(context),
-        borderRadius: AppShapes.large,
-        child: Container(
-          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
-          decoration: BoxDecoration(
-            color: Color(priority.colorValue).withAlpha(25),
-            borderRadius: AppShapes.large,
-            border: Border.all(
-              color: Color(priority.colorValue).withAlpha(76),
-              width: 1.5,
-            ),
-          ),
-          child: Row(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              Text(priority.icon, style: const TextStyle(fontSize: 16)),
-              const SizedBox(width: 8),
-              Text(
-                priority.displayName,
-                style: TextStyle(
-                  fontSize: 13,
-                  fontWeight: FontWeight.w600,
-                  color: Color(priority.colorValue),
-                ),
+      child: Tooltip(
+        message: 'Change priority',
+        excludeFromSemantics: true,
+        child: InkWell(
+          onTap: () => _showPriorityPicker(context),
+          borderRadius: AppShapes.large,
+          child: Container(
+            padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+            decoration: BoxDecoration(
+              color: Color(priority.colorValue).withAlpha(25),
+              borderRadius: AppShapes.large,
+              border: Border.all(
+                color: Color(priority.colorValue).withAlpha(76),
+                width: 1.5,
               ),
-            ],
+            ),
+            child: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Text(priority.icon, style: const TextStyle(fontSize: 16)),
+                const SizedBox(width: 8),
+                Text(
+                  priority.displayName,
+                  style: TextStyle(
+                    fontSize: 13,
+                    fontWeight: FontWeight.w600,
+                    color: Color(priority.colorValue),
+                  ),
+                ),
+              ],
+            ),
           ),
         ),
       ),


### PR DESCRIPTION
💡 What: Added a missing `Tooltip` wrapper with `excludeFromSemantics: true` to the `InkWell` in the `_buildFullChip` method of `PrioritySelector`.
🎯 Why: Desktop and web users relying on a mouse were not receiving hover feedback/context (a tooltip) on this interactive chip, despite it having a Semantics wrapper. The compact version already had a tooltip, so this fixes an inconsistency.
📸 Before/After: Visual tooltip appears when hovering over the full priority chip.
♿ Accessibility: Desktop hover context is provided. Screen reader duplication is avoided by explicitly excluding the Tooltip text from the semantic tree, as the parent Semantics node already provides comprehensive labels.

---
*PR created automatically by Jules for task [15900923169773034627](https://jules.google.com/task/15900923169773034627) started by @Gameaday*