### PR TITLE
🎨 Palette: Accessibility improvements for Settings screen custom radio buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -67,3 +67,7 @@
 ## 2025-05-19 - Added missing Tooltip to Priority Selector Full Chip
 **Learning:** Even when custom widgets (like the priority chip using `InkWell`) have proper `Semantics` wrappers, they often lack `Tooltip` wrappers. This creates an inconsistent experience where screen reader users get proper context, but desktop/web users using a mouse get no hover tooltip indicating the element is interactive and what it does.
 **Action:** When adding accessibility to custom interactive components, always ensure that both `Semantics` (for screen readers) and `Tooltip` (for visual hover context) are implemented, and remember to use `excludeFromSemantics: true` on the `Tooltip` to prevent duplicate announcements.
+
+## 2024-05-18 - Semantics wrappers for custom InkWell radio buttons
+**Learning:** When using `InkWell` to build custom form controls like radio button groups (e.g., ThemeMode, BandwidthPreset selection), using visual cues alone is insufficient for screen readers. They won't announce the options as selectable buttons or read their selected state.
+**Action:** Always wrap `InkWell` custom radio options in a `Semantics` widget with `button: true`, `inMutuallyExclusiveGroup: true`, `selected: isSelected`, and a descriptive `label` that clearly indicates what the option represents (e.g., 'Theme: System Default').

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -527,94 +527,103 @@ class _SettingsScreenState extends State<SettingsScreen> {
                 // Theme mode options
                 ...ThemeMode.values.map((mode) {
                   final isSelected = selectedMode == mode;
-                  return InkWell(
-                    onTap: () {
-                      setState(() {
-                        selectedMode = mode;
-                      });
-                    },
-                    borderRadius: BorderRadius.circular(8),
-                    child: Container(
-                      padding: const EdgeInsets.all(12.0),
-                      margin: const EdgeInsets.only(bottom: 8.0),
-                      decoration: BoxDecoration(
-                        border: Border.all(
-                          color: isSelected
-                              ? Theme.of(context).colorScheme.primary
-                              : Theme.of(context).colorScheme.outline,
-                          width: isSelected ? 2 : 1,
-                        ),
-                        borderRadius: BorderRadius.circular(8),
-                        color: isSelected
-                            ? Theme.of(context).colorScheme.primaryContainer
-                                  .withValues(alpha: 0.3)
-                            : null,
-                      ),
-                      child: Row(
-                        children: [
-                          // Custom radio indicator
-                          Container(
-                            width: 20,
-                            height: 20,
-                            decoration: BoxDecoration(
-                              shape: BoxShape.circle,
-                              border: Border.all(
-                                color: isSelected
-                                    ? Theme.of(context).colorScheme.primary
-                                    : Theme.of(context).colorScheme.outline,
-                                width: 2,
-                              ),
-                            ),
-                            child: isSelected
-                                ? Center(
-                                    child: Container(
-                                      width: 10,
-                                      height: 10,
-                                      decoration: BoxDecoration(
-                                        shape: BoxShape.circle,
-                                        color: Theme.of(
-                                          context,
-                                        ).colorScheme.primary,
-                                      ),
-                                    ),
-                                  )
-                                : null,
-                          ),
-                          const SizedBox(width: 12),
-                          Icon(
-                            ThemeProvider.getThemeModeIcon(mode),
+                  final modeName = ThemeProvider.getThemeModeName(mode);
+                  return Semantics(
+                    button: true,
+                    inMutuallyExclusiveGroup: true,
+                    selected: isSelected,
+                    label: 'Theme: $modeName',
+                    child: InkWell(
+                      onTap: () {
+                        setState(() {
+                          selectedMode = mode;
+                        });
+                      },
+                      borderRadius: BorderRadius.circular(8),
+                      child: Container(
+                        padding: const EdgeInsets.all(12.0),
+                        margin: const EdgeInsets.only(bottom: 8.0),
+                        decoration: BoxDecoration(
+                          border: Border.all(
                             color: isSelected
                                 ? Theme.of(context).colorScheme.primary
-                                : null,
+                                : Theme.of(context).colorScheme.outline,
+                            width: isSelected ? 2 : 1,
                           ),
-                          const SizedBox(width: 12),
-                          Expanded(
-                            child: Column(
-                              crossAxisAlignment: CrossAxisAlignment.start,
-                              children: [
-                                Text(
-                                  ThemeProvider.getThemeModeName(mode),
-                                  style: Theme.of(context).textTheme.titleMedium
-                                      ?.copyWith(
-                                        fontWeight: isSelected
-                                            ? FontWeight.bold
-                                            : FontWeight.normal,
-                                      ),
+                          borderRadius: BorderRadius.circular(8),
+                          color: isSelected
+                              ? Theme.of(context).colorScheme.primaryContainer
+                                    .withValues(alpha: 0.3)
+                              : null,
+                        ),
+                        child: Row(
+                          children: [
+                            // Custom radio indicator
+                            Container(
+                              width: 20,
+                              height: 20,
+                              decoration: BoxDecoration(
+                                shape: BoxShape.circle,
+                                border: Border.all(
+                                  color: isSelected
+                                      ? Theme.of(context).colorScheme.primary
+                                      : Theme.of(context).colorScheme.outline,
+                                  width: 2,
                                 ),
-                                const SizedBox(height: 4),
-                                Text(
-                                  ThemeProvider.getThemeModeDescription(mode),
-                                  style: Theme.of(context).textTheme.bodySmall
-                                      ?.copyWith(
-                                        color: Theme.of(
-                                          context,
-                                        ).colorScheme.onSurfaceVariant,
+                              ),
+                              child: isSelected
+                                  ? Center(
+                                      child: Container(
+                                        width: 10,
+                                        height: 10,
+                                        decoration: BoxDecoration(
+                                          shape: BoxShape.circle,
+                                          color: Theme.of(
+                                            context,
+                                          ).colorScheme.primary,
+                                        ),
                                       ),
-                                ),
-                              ],
+                                    )
+                                  : null,
                             ),
-                          ),
-                        ],
+                            const SizedBox(width: 12),
+                            Icon(
+                              ThemeProvider.getThemeModeIcon(mode),
+                              color: isSelected
+                                  ? Theme.of(context).colorScheme.primary
+                                  : null,
+                            ),
+                            const SizedBox(width: 12),
+                            Expanded(
+                              child: Column(
+                                crossAxisAlignment: CrossAxisAlignment.start,
+                                children: [
+                                  Text(
+                                    ThemeProvider.getThemeModeName(mode),
+                                    style: Theme.of(context)
+                                        .textTheme
+                                        .titleMedium
+                                        ?.copyWith(
+                                          fontWeight: isSelected
+                                              ? FontWeight.bold
+                                              : FontWeight.normal,
+                                        ),
+                                  ),
+                                  const SizedBox(height: 4),
+                                  Text(
+                                    ThemeProvider.getThemeModeDescription(mode),
+                                    style: Theme.of(context).textTheme.bodySmall
+                                        ?.copyWith(
+                                          color: Theme.of(
+                                            context,
+                                          ).colorScheme.onSurfaceVariant,
+                                        ),
+                                  ),
+                                ],
+                              ),
+                            ),
+                          ],
+                        ),
                       ),
                     ),
                   );
@@ -721,95 +730,101 @@ class _SettingsScreenState extends State<SettingsScreen> {
                 // Custom radio selection to avoid deprecated API
                 ...BandwidthPreset.values.map((preset) {
                   final isSelected = selectedPreset == preset;
-                  return InkWell(
-                    onTap: () {
-                      setState(() {
-                        selectedPreset = preset;
-                      });
-                    },
-                    borderRadius: BorderRadius.circular(8),
-                    child: Container(
-                      padding: const EdgeInsets.all(12.0),
-                      margin: const EdgeInsets.only(bottom: 8.0),
-                      decoration: BoxDecoration(
-                        border: Border.all(
+                  return Semantics(
+                    button: true,
+                    inMutuallyExclusiveGroup: true,
+                    selected: isSelected,
+                    label: 'Bandwidth: ${preset.displayName}',
+                    child: InkWell(
+                      onTap: () {
+                        setState(() {
+                          selectedPreset = preset;
+                        });
+                      },
+                      borderRadius: BorderRadius.circular(8),
+                      child: Container(
+                        padding: const EdgeInsets.all(12.0),
+                        margin: const EdgeInsets.only(bottom: 8.0),
+                        decoration: BoxDecoration(
+                          border: Border.all(
+                            color: isSelected
+                                ? Theme.of(context).colorScheme.primary
+                                : Theme.of(context).colorScheme.outline,
+                            width: isSelected ? 2 : 1,
+                          ),
+                          borderRadius: BorderRadius.circular(8),
                           color: isSelected
-                              ? Theme.of(context).colorScheme.primary
-                              : Theme.of(context).colorScheme.outline,
-                          width: isSelected ? 2 : 1,
+                              ? Theme.of(context).colorScheme.primaryContainer
+                                    .withValues(alpha: 0.3)
+                              : null,
                         ),
-                        borderRadius: BorderRadius.circular(8),
-                        color: isSelected
-                            ? Theme.of(context).colorScheme.primaryContainer
-                                  .withValues(alpha: 0.3)
-                            : null,
-                      ),
-                      child: Row(
-                        children: [
-                          // Custom radio indicator
-                          Container(
-                            width: 20,
-                            height: 20,
-                            decoration: BoxDecoration(
-                              shape: BoxShape.circle,
-                              border: Border.all(
-                                color: isSelected
-                                    ? Theme.of(context).colorScheme.primary
-                                    : Theme.of(context).colorScheme.outline,
-                                width: 2,
+                        child: Row(
+                          children: [
+                            // Custom radio indicator
+                            Container(
+                              width: 20,
+                              height: 20,
+                              decoration: BoxDecoration(
+                                shape: BoxShape.circle,
+                                border: Border.all(
+                                  color: isSelected
+                                      ? Theme.of(context).colorScheme.primary
+                                      : Theme.of(context).colorScheme.outline,
+                                  width: 2,
+                                ),
+                              ),
+                              child: isSelected
+                                  ? Center(
+                                      child: Container(
+                                        width: 10,
+                                        height: 10,
+                                        decoration: BoxDecoration(
+                                          shape: BoxShape.circle,
+                                          color: Theme.of(
+                                            context,
+                                          ).colorScheme.primary,
+                                        ),
+                                      ),
+                                    )
+                                  : null,
+                            ),
+                            const SizedBox(width: 12),
+                            Expanded(
+                              child: Column(
+                                crossAxisAlignment: CrossAxisAlignment.start,
+                                children: [
+                                  Row(
+                                    children: [
+                                      Text(preset.icon),
+                                      const SizedBox(width: 8),
+                                      Text(
+                                        preset.displayName,
+                                        style: Theme.of(context)
+                                            .textTheme
+                                            .titleMedium
+                                            ?.copyWith(
+                                              fontWeight: isSelected
+                                                  ? FontWeight.bold
+                                                  : FontWeight.normal,
+                                            ),
+                                      ),
+                                    ],
+                                  ),
+                                  const SizedBox(height: 4),
+                                  Text(
+                                    preset.description,
+                                    style: Theme.of(context).textTheme.bodySmall
+                                        ?.copyWith(
+                                          color: Theme.of(
+                                            context,
+                                          ).colorScheme.onSurfaceVariant,
+                                        ),
+                                  ),
+                                ],
                               ),
                             ),
-                            child: isSelected
-                                ? Center(
-                                    child: Container(
-                                      width: 10,
-                                      height: 10,
-                                      decoration: BoxDecoration(
-                                        shape: BoxShape.circle,
-                                        color: Theme.of(
-                                          context,
-                                        ).colorScheme.primary,
-                                      ),
-                                    ),
-                                  )
-                                : null,
-                          ),
-                          const SizedBox(width: 12),
-                          Expanded(
-                            child: Column(
-                              crossAxisAlignment: CrossAxisAlignment.start,
-                              children: [
-                                Row(
-                                  children: [
-                                    Text(preset.icon),
-                                    const SizedBox(width: 8),
-                                    Text(
-                                      preset.displayName,
-                                      style: Theme.of(context)
-                                          .textTheme
-                                          .titleMedium
-                                          ?.copyWith(
-                                            fontWeight: isSelected
-                                                ? FontWeight.bold
-                                                : FontWeight.normal,
-                                          ),
-                                    ),
-                                  ],
-                                ),
-                                const SizedBox(height: 4),
-                                Text(
-                                  preset.description,
-                                  style: Theme.of(context).textTheme.bodySmall
-                                      ?.copyWith(
-                                        color: Theme.of(
-                                          context,
-                                        ).colorScheme.onSurfaceVariant,
-                                      ),
-                                ),
-                              ],
-                            ),
-                          ),
-                        ],
+                          ],
+                        ),
                       ),
                     ),
                   );


### PR DESCRIPTION
💡 **What**: Added `Semantics` wrappers around the custom `InkWell` radio buttons used for selecting `ThemeMode` and `BandwidthPreset`. 
🎯 **Why**: Using an `InkWell` to build custom form controls is not sufficient for screen readers, which won't naturally announce these items as selectable buttons or read their selected state. This makes it impossible for visually impaired users to easily switch themes or download limits.
📸 **Before/After**: Visually identical, but the semantics tree now properly identifies these buttons in mutually exclusive groups.
♿ **Accessibility**: 
- Added `button: true`
- Added `inMutuallyExclusiveGroup: true`
- Added `selected: isSelected`
- Added a descriptive `label` indicating what the option is (e.g. 'Theme: System Default')

---
*PR created automatically by Jules for task [5963725481735481950](https://jules.google.com/task/5963725481735481950) started by @Gameaday*