### PR TITLE
🎨 Palette: Prevent redundant Tooltip screen reader readouts

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -71,3 +71,6 @@
 ## 2024-05-18 - Semantics wrappers for custom InkWell radio buttons
 **Learning:** When using `InkWell` to build custom form controls like radio button groups (e.g., ThemeMode, BandwidthPreset selection), using visual cues alone is insufficient for screen readers. They won't announce the options as selectable buttons or read their selected state.
 **Action:** Always wrap `InkWell` custom radio options in a `Semantics` widget with `button: true`, `inMutuallyExclusiveGroup: true`, `selected: isSelected`, and a descriptive `label` that clearly indicates what the option represents (e.g., 'Theme: System Default').
+## 2024-05-19 - Avoid redundant Semantics and Tooltip in Flutter
+**Learning:** In Flutter, combining explicit `Semantics` and `Tooltip` on the same interactive element can cause redundant screen reader readouts since both provide accessibility text to the OS.
+**Action:** Use `excludeFromSemantics: true` on the `Tooltip` to prevent duplication, ensuring the tooltip provides hover context without confusing screen reader users.

--- a/lib/widgets/archive_preview_widget.dart
+++ b/lib/widgets/archive_preview_widget.dart
@@ -330,6 +330,7 @@ class _ArchivePreviewWidgetState extends State<ArchivePreviewWidget> {
             button: true,
             label: isExpanded ? 'Collapse directory' : 'Expand directory',
             child: Tooltip(
+              excludeFromSemantics: true,
               message: isExpanded ? 'Collapse directory' : 'Expand directory',
               child: InkWell(
                 onTap: () => _toggleFolder(dirPath),
@@ -389,6 +390,7 @@ class _ArchivePreviewWidgetState extends State<ArchivePreviewWidget> {
       button: true,
       label: 'Select file $filename',
       child: Tooltip(
+        excludeFromSemantics: true,
         message: 'Select file $filename',
         child: InkWell(
           onTap: () => _selectFile(file),

--- a/lib/widgets/archive_result_card.dart
+++ b/lib/widgets/archive_result_card.dart
@@ -47,6 +47,7 @@ class ArchiveResultCard extends StatelessWidget {
       button: true,
       enabled: true,
       child: Tooltip(
+        excludeFromSemantics: true,
         message: 'View ${result.title}',
         child: Card(
           clipBehavior: Clip.antiAlias,
@@ -156,6 +157,7 @@ class ArchiveResultCard extends StatelessWidget {
       button: true,
       enabled: true,
       child: Tooltip(
+        excludeFromSemantics: true,
         message: 'View ${result.title}',
         child: Card(
           clipBehavior: Clip.antiAlias,

--- a/lib/widgets/pdf_preview_widget.dart
+++ b/lib/widgets/pdf_preview_widget.dart
@@ -233,6 +233,7 @@ class _PdfPreviewWidgetState extends State<PdfPreviewWidget> {
                       label: 'Current page $_currentPage, tap to jump to page',
                       button: true,
                       child: Tooltip(
+                        excludeFromSemantics: true,
                         message: 'Jump to page',
                         child: GestureDetector(
                           onTap: _showPageJumpDialog,

--- a/lib/widgets/search_suggestion_card.dart
+++ b/lib/widgets/search_suggestion_card.dart
@@ -19,6 +19,7 @@ class SearchSuggestionCard extends StatelessWidget {
       button: true,
       label: 'Suggestion: ${suggestion.title}',
       child: Tooltip(
+        excludeFromSemantics: true,
         message: 'View ${suggestion.title}',
         child: Card(
           margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),


### PR DESCRIPTION
💡 What:
Added `excludeFromSemantics: true` to Tooltips wrapping InkWells and GestureDetectors that already have explicit Semantics labels.

🎯 Why:
In Flutter, combining `Semantics(label: '...')` with a `Tooltip(message: '...')` causes screen readers to read the text twice. Setting `excludeFromSemantics: true` ensures the Tooltip acts purely as visual hover context without cluttering the accessibility tree.

📸 Before/After:
N/A - purely accessibility tree change, no visual changes.

♿ Accessibility:
Prevents redundant/double screen reader announcements on interactive cards and custom buttons across multiple views (archive preview, result card, search suggestion card, pdf viewer).

---
*PR created automatically by Jules for task [6024268424458944351](https://jules.google.com/task/6024268424458944351) started by @Gameaday*