### PR TITLE
🎨 Palette: Add accessibility wrappers to field search toggle

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -74,3 +74,7 @@
 ## 2024-05-19 - Avoid redundant Semantics and Tooltip in Flutter
 **Learning:** In Flutter, combining explicit `Semantics` and `Tooltip` on the same interactive element can cause redundant screen reader readouts since both provide accessibility text to the OS.
 **Action:** Use `excludeFromSemantics: true` on the `Tooltip` to prevent duplication, ensuring the tooltip provides hover context without confusing screen reader users.
+
+## 2024-05-18 - Nested Interactive Element Accessibility
+**Learning:** In Flutter, when wrapping interactive elements like `Card` and its internal `InkWell` for accessibility, applying both `Semantics` and `Tooltip` wrappers directly over the `Card` effectively communicates the interaction to screen readers and mouse users. However, `Tooltip` widgets read their `message` out loud to screen readers by default. When wrapping `Semantics` and `Tooltip` together on the same element, you must add `excludeFromSemantics: true` to the `Tooltip` to prevent redundant audio announcements.
+**Action:** When creating toggleable sections or actionable cards containing `InkWell`, always place the `Semantics(button: true)` and `Tooltip(excludeFromSemantics: true)` outside the bounding parent (e.g. `Card`) and update their labels dynamically based on the toggle state (e.g., 'Expand' vs 'Collapse').

--- a/lib/screens/advanced_search_screen.dart
+++ b/lib/screens/advanced_search_screen.dart
@@ -439,30 +439,42 @@ class _AdvancedSearchScreenState extends State<AdvancedSearchScreen> {
   }
 
   Widget _buildFieldSearchToggle() {
-    return Card(
-      child: InkWell(
-        onTap: () => setState(() => _showFieldSearch = !_showFieldSearch),
-        child: Padding(
-          padding: const EdgeInsets.all(16),
-          child: Row(
-            children: [
-              Icon(
-                _showFieldSearch ? Icons.expand_less : Icons.expand_more,
-                color: Theme.of(context).colorScheme.primary,
+    return Semantics(
+      button: true,
+      label: _showFieldSearch
+          ? 'Collapse Field-Specific Search'
+          : 'Expand Field-Specific Search',
+      child: Tooltip(
+        excludeFromSemantics: true,
+        message: _showFieldSearch
+            ? 'Collapse Field-Specific Search'
+            : 'Expand Field-Specific Search',
+        child: Card(
+          child: InkWell(
+            onTap: () => setState(() => _showFieldSearch = !_showFieldSearch),
+            child: Padding(
+              padding: const EdgeInsets.all(16),
+              child: Row(
+                children: [
+                  Icon(
+                    _showFieldSearch ? Icons.expand_less : Icons.expand_more,
+                    color: Theme.of(context).colorScheme.primary,
+                  ),
+                  const SizedBox(width: 12),
+                  Text(
+                    'Field-Specific Search',
+                    style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                      color: Theme.of(context).colorScheme.primary,
+                    ),
+                  ),
+                  const Spacer(),
+                  if (_titleController.text.isNotEmpty ||
+                      _creatorController.text.isNotEmpty ||
+                      _subjectController.text.isNotEmpty)
+                    const Icon(Icons.check_circle, color: Color(0xFF2E7D32)),
+                ],
               ),
-              const SizedBox(width: 12),
-              Text(
-                'Field-Specific Search',
-                style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                  color: Theme.of(context).colorScheme.primary,
-                ),
-              ),
-              const Spacer(),
-              if (_titleController.text.isNotEmpty ||
-                  _creatorController.text.isNotEmpty ||
-                  _subjectController.text.isNotEmpty)
-                const Icon(Icons.check_circle, color: Color(0xFF2E7D32)),
-            ],
+            ),
           ),
         ),
       ),


### PR DESCRIPTION
### 💡 What
Added `Semantics` and `Tooltip` wrappers to the "Field-Specific Search" toggle card in `AdvancedSearchScreen`. The label dynamically updates to indicate if the section will "Expand" or "Collapse".

### 🎯 Why
The `InkWell` providing the toggle interaction was lacking semantic labeling, making it invisible to screen readers as an actionable button. This change makes the advanced search screen more accessible to all users.

### ♿ Accessibility
- Added `Semantics(button: true)` wrapper.
- Added dynamic label ('Expand Field-Specific Search' vs 'Collapse Field-Specific Search').
- Added `Tooltip(excludeFromSemantics: true)` for mouse hover context without duplicating screen reader audio.

---
*PR created automatically by Jules for task [3462375965999312451](https://jules.google.com/task/3462375965999312451) started by @Gameaday*