### PR TITLE
🎨 Palette: Add tooltip to saved searches card

### DIFF
--- a/lib/screens/saved_searches_screen.dart
+++ b/lib/screens/saved_searches_screen.dart
@@ -496,164 +496,168 @@ class _SavedSearchesScreenState extends State<SavedSearchesScreen> {
     return Semantics(
       button: true,
       label: 'Saved search: ${search.name}',
-      child: Card(
-        margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-        child: InkWell(
-          onTap: () => _loadSearch(search),
-          borderRadius: BorderRadius.circular(12),
-          child: Padding(
-            padding: const EdgeInsets.all(16),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Row(
-                  children: [
-                    if (search.isPinned)
-                      Padding(
-                        padding: const EdgeInsets.only(right: 8),
-                        child: Icon(
-                          Icons.push_pin,
-                          size: 20,
-                          color: Theme.of(context).colorScheme.primary,
-                        ),
-                      ),
-                    Expanded(
-                      child: Text(
-                        search.name,
-                        style: Theme.of(context).textTheme.titleMedium,
-                        maxLines: 1,
-                        overflow: TextOverflow.ellipsis,
-                      ),
-                    ),
-                    IconButton(
-                      icon: Icon(
-                        search.isPinned
-                            ? Icons.push_pin
-                            : Icons.push_pin_outlined,
-                        color: search.isPinned
-                            ? Theme.of(context).colorScheme.primary
-                            : Theme.of(context).colorScheme.outline,
-                      ),
-                      onPressed: () => _togglePin(search),
-                      tooltip: search.isPinned ? 'Unpin' : 'Pin',
-                    ),
-                    PopupMenuButton(
-                      itemBuilder: (context) => [
-                        const PopupMenuItem(
-                          value: 'edit',
-                          child: Row(
-                            children: [
-                              Icon(Icons.edit),
-                              SizedBox(width: 12),
-                              Text('Edit'),
-                            ],
+      child: Tooltip(
+        excludeFromSemantics: true,
+        message: 'Load search ${search.name}',
+        child: Card(
+          margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+          child: InkWell(
+            onTap: () => _loadSearch(search),
+            borderRadius: BorderRadius.circular(12),
+            child: Padding(
+              padding: const EdgeInsets.all(16),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Row(
+                    children: [
+                      if (search.isPinned)
+                        Padding(
+                          padding: const EdgeInsets.only(right: 8),
+                          child: Icon(
+                            Icons.push_pin,
+                            size: 20,
+                            color: Theme.of(context).colorScheme.primary,
                           ),
                         ),
-                        const PopupMenuItem(
-                          value: 'tags',
-                          child: Row(
-                            children: [
-                              Icon(Icons.label),
-                              SizedBox(width: 12),
-                              Text('Manage Tags'),
-                            ],
-                          ),
+                      Expanded(
+                        child: Text(
+                          search.name,
+                          style: Theme.of(context).textTheme.titleMedium,
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
                         ),
-                        PopupMenuItem(
-                          value: 'delete',
-                          child: Row(
-                            children: [
-                              Icon(
-                                Icons.delete,
-                                color: Theme.of(context).colorScheme.error,
-                              ),
-                              const SizedBox(width: 12),
-                              Text(
-                                'Delete',
-                                style: TextStyle(
+                      ),
+                      IconButton(
+                        icon: Icon(
+                          search.isPinned
+                              ? Icons.push_pin
+                              : Icons.push_pin_outlined,
+                          color: search.isPinned
+                              ? Theme.of(context).colorScheme.primary
+                              : Theme.of(context).colorScheme.outline,
+                        ),
+                        onPressed: () => _togglePin(search),
+                        tooltip: search.isPinned ? 'Unpin' : 'Pin',
+                      ),
+                      PopupMenuButton(
+                        itemBuilder: (context) => [
+                          const PopupMenuItem(
+                            value: 'edit',
+                            child: Row(
+                              children: [
+                                Icon(Icons.edit),
+                                SizedBox(width: 12),
+                                Text('Edit'),
+                              ],
+                            ),
+                          ),
+                          const PopupMenuItem(
+                            value: 'tags',
+                            child: Row(
+                              children: [
+                                Icon(Icons.label),
+                                SizedBox(width: 12),
+                                Text('Manage Tags'),
+                              ],
+                            ),
+                          ),
+                          PopupMenuItem(
+                            value: 'delete',
+                            child: Row(
+                              children: [
+                                Icon(
+                                  Icons.delete,
                                   color: Theme.of(context).colorScheme.error,
                                 ),
-                              ),
-                            ],
+                                const SizedBox(width: 12),
+                                Text(
+                                  'Delete',
+                                  style: TextStyle(
+                                    color: Theme.of(context).colorScheme.error,
+                                  ),
+                                ),
+                              ],
+                            ),
                           ),
-                        ),
-                      ],
-                      onSelected: (value) {
-                        switch (value) {
-                          case 'edit':
-                            _editSearch(search);
-                          case 'tags':
-                            _manageTagsForSearch(search);
-                          case 'delete':
-                            _deleteSearch(search);
-                        }
-                      },
-                    ),
-                  ],
-                ),
-                const SizedBox(height: 8),
-                Text(
-                  search.summary,
-                  style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                    color: Theme.of(context).colorScheme.onSurfaceVariant,
+                        ],
+                        onSelected: (value) {
+                          switch (value) {
+                            case 'edit':
+                              _editSearch(search);
+                            case 'tags':
+                              _manageTagsForSearch(search);
+                            case 'delete':
+                              _deleteSearch(search);
+                          }
+                        },
+                      ),
+                    ],
                   ),
-                  maxLines: 2,
-                  overflow: TextOverflow.ellipsis,
-                ),
-                if (search.description != null) ...[
                   const SizedBox(height: 8),
                   Text(
-                    search.description!,
-                    style: Theme.of(context).textTheme.bodySmall,
+                    search.summary,
+                    style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                      color: Theme.of(context).colorScheme.onSurfaceVariant,
+                    ),
                     maxLines: 2,
                     overflow: TextOverflow.ellipsis,
                   ),
-                ],
-                if (search.tags.isNotEmpty) ...[
-                  const SizedBox(height: 12),
-                  Wrap(
-                    spacing: 8,
-                    runSpacing: 4,
-                    children: search.tags.map((tag) {
-                      return Chip(
-                        label: Text(tag),
-                        labelStyle: Theme.of(context).textTheme.bodySmall,
-                        visualDensity: VisualDensity.compact,
-                      );
-                    }).toList(),
-                  ),
-                ],
-                const SizedBox(height: 12),
-                Row(
-                  children: [
-                    Icon(
-                      Icons.access_time,
-                      size: 16,
-                      color: Theme.of(context).colorScheme.outline,
-                    ),
-                    const SizedBox(width: 4),
+                  if (search.description != null) ...[
+                    const SizedBox(height: 8),
                     Text(
-                      search.lastUsedDisplay,
-                      style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                        color: Theme.of(context).colorScheme.outline,
-                      ),
-                    ),
-                    const SizedBox(width: 16),
-                    Icon(
-                      Icons.analytics,
-                      size: 16,
-                      color: Theme.of(context).colorScheme.outline,
-                    ),
-                    const SizedBox(width: 4),
-                    Text(
-                      '${search.useCount} uses',
-                      style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                        color: Theme.of(context).colorScheme.outline,
-                      ),
+                      search.description!,
+                      style: Theme.of(context).textTheme.bodySmall,
+                      maxLines: 2,
+                      overflow: TextOverflow.ellipsis,
                     ),
                   ],
-                ),
-              ],
+                  if (search.tags.isNotEmpty) ...[
+                    const SizedBox(height: 12),
+                    Wrap(
+                      spacing: 8,
+                      runSpacing: 4,
+                      children: search.tags.map((tag) {
+                        return Chip(
+                          label: Text(tag),
+                          labelStyle: Theme.of(context).textTheme.bodySmall,
+                          visualDensity: VisualDensity.compact,
+                        );
+                      }).toList(),
+                    ),
+                  ],
+                  const SizedBox(height: 12),
+                  Row(
+                    children: [
+                      Icon(
+                        Icons.access_time,
+                        size: 16,
+                        color: Theme.of(context).colorScheme.outline,
+                      ),
+                      const SizedBox(width: 4),
+                      Text(
+                        search.lastUsedDisplay,
+                        style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                          color: Theme.of(context).colorScheme.outline,
+                        ),
+                      ),
+                      const SizedBox(width: 16),
+                      Icon(
+                        Icons.analytics,
+                        size: 16,
+                        color: Theme.of(context).colorScheme.outline,
+                      ),
+                      const SizedBox(width: 4),
+                      Text(
+                        '${search.useCount} uses',
+                        style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                          color: Theme.of(context).colorScheme.outline,
+                        ),
+                      ),
+                    ],
+                  ),
+                ],
+              ),
             ),
           ),
         ),


### PR DESCRIPTION
💡 What: Wrapped the `Card` component inside the saved searches list with a `Tooltip(excludeFromSemantics: true)`.
🎯 Why: Desktop users interacting with a mouse could not see what the card did, while the screen reader correctly identified it. We improved desktop usability without degrading screen reader accessibility.
📸 Before/After: Hovering over the card now yields a tooltip "Load search {name}".
♿ Accessibility: Preserved previous screen reader functionality via `excludeFromSemantics: true`.

---
*PR created automatically by Jules for task [17986025139596463444](https://jules.google.com/task/17986025139596463444) started by @Gameaday*