### PR TITLE
🎨 Palette: Add Semantics and Tooltips to Library and Favorites Cards

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -78,3 +78,7 @@
 ## 2024-05-18 - Nested Interactive Element Accessibility
 **Learning:** In Flutter, when wrapping interactive elements like `Card` and its internal `InkWell` for accessibility, applying both `Semantics` and `Tooltip` wrappers directly over the `Card` effectively communicates the interaction to screen readers and mouse users. However, `Tooltip` widgets read their `message` out loud to screen readers by default. When wrapping `Semantics` and `Tooltip` together on the same element, you must add `excludeFromSemantics: true` to the `Tooltip` to prevent redundant audio announcements.
 **Action:** When creating toggleable sections or actionable cards containing `InkWell`, always place the `Semantics(button: true)` and `Tooltip(excludeFromSemantics: true)` outside the bounding parent (e.g. `Card`) and update their labels dynamically based on the toggle state (e.g., 'Expand' vs 'Collapse').
+
+## 2026-05-30 - Tooltip and Semantics placement for actionable lists
+**Learning:** When making `Card` elements actionable in grid or list views via internal `InkWell` components (e.g., in `FavoritesScreen` or `LibraryScreen`), they must be wrapped in `Semantics(button: true)` and `Tooltip(excludeFromSemantics: true)` to ensure screen readers announce them properly as interactive elements without duplicate announcements, and desktop users see a helpful hover state context.
+**Action:** Always verify that grid items and list tiles that wrap `Card` + `InkWell` use both `Semantics` and `Tooltip`.

--- a/lib/screens/favorites_screen.dart
+++ b/lib/screens/favorites_screen.dart
@@ -333,87 +333,95 @@ class _FavoritesScreenState extends State<FavoritesScreen> {
     return Semantics(
       button: true,
       label: 'Favorite: ${favorite.displayTitle}',
-      child: Card(
-        clipBehavior: Clip.antiAlias,
-        child: InkWell(
-          onTap: () => _navigateToDetail(favorite),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              // Thumbnail placeholder
-              AspectRatio(
-                aspectRatio: 1,
-                child: Container(
-                  color: colorScheme.surfaceContainerHighest,
-                  child: Icon(
-                    _getIconForMediaType(favorite.mediatype),
-                    size: 48,
-                    color: colorScheme.onSurfaceVariant,
-                  ),
-                ),
-              ),
-              Expanded(
-                child: Padding(
-                  padding: const EdgeInsets.all(12),
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      Text(
-                        favorite.displayTitle,
-                        style: theme.textTheme.titleSmall,
-                        maxLines: 2,
-                        overflow: TextOverflow.ellipsis,
-                      ),
-                      if (favorite.mediatype != null) ...[
-                        const SizedBox(height: 4),
-                        Text(
-                          favorite.mediatype!,
-                          style: theme.textTheme.bodySmall?.copyWith(
-                            color: colorScheme.onSurfaceVariant,
-                          ),
-                          maxLines: 1,
-                          overflow: TextOverflow.ellipsis,
+      child: Tooltip(
+        excludeFromSemantics: true,
+        message: 'View ${favorite.displayTitle}',
+        child: Card(
+          clipBehavior: Clip.antiAlias,
+          child: InkWell(
+            onTap: () => _navigateToDetail(favorite),
+            child: Stack(
+              children: [
+                Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    // Thumbnail placeholder
+                    AspectRatio(
+                      aspectRatio: 1,
+                      child: Container(
+                        color: colorScheme.surfaceContainerHighest,
+                        child: Icon(
+                          _getIconForMediaType(favorite.mediatype),
+                          size: 48,
+                          color: colorScheme.onSurfaceVariant,
                         ),
-                      ],
-                      const Spacer(),
-                      Row(
-                        children: [
-                          Icon(
-                            Icons.access_time,
-                            size: 12,
-                            color: colorScheme.onSurfaceVariant,
-                          ),
-                          const SizedBox(width: 4),
-                          Expanded(
-                            child: Text(
-                              favorite.formattedAddedDate,
-                              style: theme.textTheme.labelSmall?.copyWith(
-                                color: colorScheme.onSurfaceVariant,
-                              ),
-                              maxLines: 1,
+                      ),
+                    ),
+                    Expanded(
+                      child: Padding(
+                        padding: const EdgeInsets.all(12),
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Text(
+                              favorite.displayTitle,
+                              style: theme.textTheme.titleSmall,
+                              maxLines: 2,
                               overflow: TextOverflow.ellipsis,
                             ),
-                          ),
-                        ],
+                            if (favorite.mediatype != null) ...[
+                              const SizedBox(height: 4),
+                              Text(
+                                favorite.mediatype!,
+                                style: theme.textTheme.bodySmall?.copyWith(
+                                  color: colorScheme.onSurfaceVariant,
+                                ),
+                                maxLines: 1,
+                                overflow: TextOverflow.ellipsis,
+                              ),
+                            ],
+                            const Spacer(),
+                            Row(
+                              children: [
+                                Icon(
+                                  Icons.access_time,
+                                  size: 12,
+                                  color: colorScheme.onSurfaceVariant,
+                                ),
+                                const SizedBox(width: 4),
+                                Expanded(
+                                  child: Text(
+                                    favorite.formattedAddedDate,
+                                    style: theme.textTheme.labelSmall?.copyWith(
+                                      color: colorScheme.onSurfaceVariant,
+                                    ),
+                                    maxLines: 1,
+                                    overflow: TextOverflow.ellipsis,
+                                  ),
+                                ),
+                              ],
+                            ),
+                          ],
+                        ),
                       ),
-                    ],
+                    ),
+                  ],
+                ),
+                // Favorite button overlay
+                Positioned(
+                  top: 8,
+                  right: 8,
+                  child: Tooltip(
+                    message: 'Remove ${favorite.displayTitle} from favorites',
+                    child: FavoriteIconButton(
+                      identifier: favorite.identifier,
+                      onFavoriteChanged: (_) =>
+                          _onFavoriteRemoved(favorite.identifier),
+                    ),
                   ),
                 ),
-              ),
-              // Favorite button overlay
-              Positioned(
-                top: 8,
-                right: 8,
-                child: Tooltip(
-                  message: 'Remove ${favorite.displayTitle} from favorites',
-                  child: FavoriteIconButton(
-                    identifier: favorite.identifier,
-                    onFavoriteChanged: (_) =>
-                        _onFavoriteRemoved(favorite.identifier),
-                  ),
-                ),
-              ),
-            ],
+              ],
+            ),
           ),
         ),
       ),
@@ -424,51 +432,63 @@ class _FavoritesScreenState extends State<FavoritesScreen> {
     final theme = Theme.of(context);
     final colorScheme = theme.colorScheme;
 
-    return Card(
-      margin: const EdgeInsets.only(bottom: 8),
-      child: ListTile(
-        contentPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-        leading: Container(
-          width: 56,
-          height: 56,
-          decoration: BoxDecoration(
-            color: colorScheme.surfaceContainerHighest,
-            borderRadius: BorderRadius.circular(8),
-          ),
-          child: Icon(
-            _getIconForMediaType(favorite.mediatype),
-            color: colorScheme.onSurfaceVariant,
-          ),
-        ),
-        title: Text(
-          favorite.displayTitle,
-          maxLines: 2,
-          overflow: TextOverflow.ellipsis,
-        ),
-        subtitle: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            if (favorite.mediatype != null) ...[
-              const SizedBox(height: 4),
-              Text(favorite.mediatype!, style: theme.textTheme.bodySmall),
-            ],
-            const SizedBox(height: 4),
-            Text(
-              favorite.formattedAddedDate,
-              style: theme.textTheme.labelSmall?.copyWith(
+    return Semantics(
+      button: true,
+      label: 'Favorite: ${favorite.displayTitle}',
+      child: Tooltip(
+        excludeFromSemantics: true,
+        message: 'View ${favorite.displayTitle}',
+        child: Card(
+          margin: const EdgeInsets.only(bottom: 8),
+          child: ListTile(
+            contentPadding: const EdgeInsets.symmetric(
+              horizontal: 16,
+              vertical: 8,
+            ),
+            leading: Container(
+              width: 56,
+              height: 56,
+              decoration: BoxDecoration(
+                color: colorScheme.surfaceContainerHighest,
+                borderRadius: BorderRadius.circular(8),
+              ),
+              child: Icon(
+                _getIconForMediaType(favorite.mediatype),
                 color: colorScheme.onSurfaceVariant,
               ),
             ),
-          ],
-        ),
-        trailing: Tooltip(
-          message: 'Remove ${favorite.displayTitle} from favorites',
-          child: FavoriteIconButton(
-            identifier: favorite.identifier,
-            onFavoriteChanged: (_) => _onFavoriteRemoved(favorite.identifier),
+            title: Text(
+              favorite.displayTitle,
+              maxLines: 2,
+              overflow: TextOverflow.ellipsis,
+            ),
+            subtitle: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                if (favorite.mediatype != null) ...[
+                  const SizedBox(height: 4),
+                  Text(favorite.mediatype!, style: theme.textTheme.bodySmall),
+                ],
+                const SizedBox(height: 4),
+                Text(
+                  favorite.formattedAddedDate,
+                  style: theme.textTheme.labelSmall?.copyWith(
+                    color: colorScheme.onSurfaceVariant,
+                  ),
+                ),
+              ],
+            ),
+            trailing: Tooltip(
+              message: 'Remove ${favorite.displayTitle} from favorites',
+              child: FavoriteIconButton(
+                identifier: favorite.identifier,
+                onFavoriteChanged: (_) =>
+                    _onFavoriteRemoved(favorite.identifier),
+              ),
+            ),
+            onTap: () => _navigateToDetail(favorite),
           ),
         ),
-        onTap: () => _navigateToDetail(favorite),
       ),
     );
   }

--- a/lib/screens/library_screen.dart
+++ b/lib/screens/library_screen.dart
@@ -601,66 +601,70 @@ class _LibraryScreenState extends State<LibraryScreen>
     return Semantics(
       button: true,
       label: 'Archive: ${archive.metadata.title ?? archive.identifier}',
-      child: Card(
-        clipBehavior: Clip.antiAlias,
-        child: InkWell(
-          onTap: () => _openArchive(archive),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              // Thumbnail placeholder
-              Container(
-                height: 120,
-                color: colorScheme.surfaceContainerHighest,
-                child: Center(
-                  child: Icon(
-                    Icons.archive,
-                    size: 48,
-                    color: colorScheme.onSurfaceVariant,
+      child: Tooltip(
+        excludeFromSemantics: true,
+        message: 'Open ${archive.metadata.title ?? archive.identifier}',
+        child: Card(
+          clipBehavior: Clip.antiAlias,
+          child: InkWell(
+            onTap: () => _openArchive(archive),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                // Thumbnail placeholder
+                Container(
+                  height: 120,
+                  color: colorScheme.surfaceContainerHighest,
+                  child: Center(
+                    child: Icon(
+                      Icons.archive,
+                      size: 48,
+                      color: colorScheme.onSurfaceVariant,
+                    ),
                   ),
                 ),
-              ),
-              Expanded(
-                child: Padding(
-                  padding: const EdgeInsets.all(12),
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      Text(
-                        archive.metadata.title ?? archive.identifier,
-                        style: theme.textTheme.titleSmall,
-                        maxLines: 2,
-                        overflow: TextOverflow.ellipsis,
-                      ),
-                      const Spacer(),
-                      Row(
-                        children: [
-                          Icon(
-                            Icons.description,
-                            size: 14,
-                            color: colorScheme.onSurfaceVariant,
-                          ),
-                          const SizedBox(width: 4),
-                          Text(
-                            '${archive.downloadedFiles} files',
-                            style: theme.textTheme.labelSmall?.copyWith(
+                Expanded(
+                  child: Padding(
+                    padding: const EdgeInsets.all(12),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          archive.metadata.title ?? archive.identifier,
+                          style: theme.textTheme.titleSmall,
+                          maxLines: 2,
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                        const Spacer(),
+                        Row(
+                          children: [
+                            Icon(
+                              Icons.description,
+                              size: 14,
                               color: colorScheme.onSurfaceVariant,
                             ),
-                          ),
-                        ],
-                      ),
-                      const SizedBox(height: 4),
-                      Text(
-                        FormattingUtils.formatBytes(archive.downloadedBytes),
-                        style: theme.textTheme.labelSmall?.copyWith(
-                          color: colorScheme.onSurfaceVariant,
+                            const SizedBox(width: 4),
+                            Text(
+                              '${archive.downloadedFiles} files',
+                              style: theme.textTheme.labelSmall?.copyWith(
+                                color: colorScheme.onSurfaceVariant,
+                              ),
+                            ),
+                          ],
                         ),
-                      ),
-                    ],
+                        const SizedBox(height: 4),
+                        Text(
+                          FormattingUtils.formatBytes(archive.downloadedBytes),
+                          style: theme.textTheme.labelSmall?.copyWith(
+                            color: colorScheme.onSurfaceVariant,
+                          ),
+                        ),
+                      ],
+                    ),
                   ),
                 ),
-              ),
-            ],
+              ],
+            ),
           ),
         ),
       ),
@@ -671,64 +675,72 @@ class _LibraryScreenState extends State<LibraryScreen>
     final theme = Theme.of(context);
     final colorScheme = theme.colorScheme;
 
-    return Card(
-      margin: const EdgeInsets.only(bottom: 12),
-      child: ListTile(
-        leading: Container(
-          width: 48,
-          height: 48,
-          decoration: BoxDecoration(
-            color: colorScheme.surfaceContainerHighest,
-            borderRadius: BorderRadius.circular(8),
+    return Semantics(
+      button: true,
+      label: 'Archive: ${archive.metadata.title ?? archive.identifier}',
+      child: Tooltip(
+        excludeFromSemantics: true,
+        message: 'Open ${archive.metadata.title ?? archive.identifier}',
+        child: Card(
+          margin: const EdgeInsets.only(bottom: 12),
+          child: ListTile(
+            leading: Container(
+              width: 48,
+              height: 48,
+              decoration: BoxDecoration(
+                color: colorScheme.surfaceContainerHighest,
+                borderRadius: BorderRadius.circular(8),
+              ),
+              child: Icon(Icons.archive, color: colorScheme.onSurfaceVariant),
+            ),
+            title: Text(
+              archive.metadata.title ?? archive.identifier,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+            ),
+            subtitle: Text(
+              '${archive.downloadedFiles} files • ${FormattingUtils.formatBytes(archive.downloadedBytes)}',
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+            ),
+            trailing: PopupMenuButton<String>(
+              onSelected: (value) => _handleArchiveAction(value, archive),
+              itemBuilder: (context) => [
+                const PopupMenuItem(
+                  value: 'open',
+                  child: Row(
+                    children: [
+                      Icon(Icons.folder_open),
+                      SizedBox(width: 12),
+                      Text('Open'),
+                    ],
+                  ),
+                ),
+                const PopupMenuItem(
+                  value: 'add_to_collection',
+                  child: Row(
+                    children: [
+                      Icon(Icons.add_to_photos),
+                      SizedBox(width: 12),
+                      Text('Add to Collection'),
+                    ],
+                  ),
+                ),
+                const PopupMenuItem(
+                  value: 'delete',
+                  child: Row(
+                    children: [
+                      Icon(Icons.delete),
+                      SizedBox(width: 12),
+                      Text('Delete'),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+            onTap: () => _openArchive(archive),
           ),
-          child: Icon(Icons.archive, color: colorScheme.onSurfaceVariant),
         ),
-        title: Text(
-          archive.metadata.title ?? archive.identifier,
-          maxLines: 1,
-          overflow: TextOverflow.ellipsis,
-        ),
-        subtitle: Text(
-          '${archive.downloadedFiles} files • ${FormattingUtils.formatBytes(archive.downloadedBytes)}',
-          maxLines: 1,
-          overflow: TextOverflow.ellipsis,
-        ),
-        trailing: PopupMenuButton<String>(
-          onSelected: (value) => _handleArchiveAction(value, archive),
-          itemBuilder: (context) => [
-            const PopupMenuItem(
-              value: 'open',
-              child: Row(
-                children: [
-                  Icon(Icons.folder_open),
-                  SizedBox(width: 12),
-                  Text('Open'),
-                ],
-              ),
-            ),
-            const PopupMenuItem(
-              value: 'add_to_collection',
-              child: Row(
-                children: [
-                  Icon(Icons.add_to_photos),
-                  SizedBox(width: 12),
-                  Text('Add to Collection'),
-                ],
-              ),
-            ),
-            const PopupMenuItem(
-              value: 'delete',
-              child: Row(
-                children: [
-                  Icon(Icons.delete),
-                  SizedBox(width: 12),
-                  Text('Delete'),
-                ],
-              ),
-            ),
-          ],
-        ),
-        onTap: () => _openArchive(archive),
       ),
     );
   }


### PR DESCRIPTION
💡 What: Added Semantics and Tooltip wrappers to actionable Card components across Library and Favorites screens. Fixed a minor invalid `Positioned` layout nesting in `FavoritesScreen`.
🎯 Why: Without these wrappers, screen readers either failed to announce the cards as unified interactive elements or lacked descriptive hover tooltips for mouse users.
📸 Before/After: Mouse users now see tooltips like "Open [Archive Name]" or "View [Favorite Title]" on hover.
♿ Accessibility: Ensures consistent behavior where cards act as interactive buttons for both screen readers (`Semantics`) and pointer devices (`Tooltip`), without redundant audio announcements (`excludeFromSemantics: true`).

---
*PR created automatically by Jules for task [15052967791180184844](https://jules.google.com/task/15052967791180184844) started by @Gameaday*