### PR TITLE
🎨 Palette: Wrap interactive Cards with Tooltip

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -82,3 +82,7 @@
 ## 2026-05-30 - Tooltip and Semantics placement for actionable lists
 **Learning:** When making `Card` elements actionable in grid or list views via internal `InkWell` components (e.g., in `FavoritesScreen` or `LibraryScreen`), they must be wrapped in `Semantics(button: true)` and `Tooltip(excludeFromSemantics: true)` to ensure screen readers announce them properly as interactive elements without duplicate announcements, and desktop users see a helpful hover state context.
 **Action:** Always verify that grid items and list tiles that wrap `Card` + `InkWell` use both `Semantics` and `Tooltip`.
+## 2026-06-05 - Avoid polluting repository with scratchpad scripts\n**Learning:** Including ad-hoc Python scripts created during codebase exploration and problem solving in the final commit pollutes the repository and degrades maintainability. They should be deleted before submitting.\n**Action:** Remember to delete local scratchpad scripts used for  alternative operations before finishing tasks and completing pre-commit steps.
+## 2026-06-05 - Avoid polluting repository with scratchpad scripts
+**Learning:** Including ad-hoc scripts (like python parsers) created during codebase exploration and problem solving in the final commit pollutes the repository and degrades maintainability. They should be deleted before submitting.
+**Action:** Remember to delete local scratchpad scripts used for text operations before finishing tasks and completing pre-commit steps.

--- a/lib/screens/discover_screen.dart
+++ b/lib/screens/discover_screen.dart
@@ -619,79 +619,92 @@ class _TrendingCard extends StatelessWidget {
     final semantics = Semantics(
       button: true,
       label: 'Trending: ${result.title}',
-      child: Card(
-        clipBehavior: Clip.antiAlias,
-        child: InkWell(
-          onTap: () async {
-            final archiveService = context.read<ArchiveService>();
+      child: Tooltip(
+        excludeFromSemantics: true,
+        message: 'View ${result.title}',
+        child: Card(
+          clipBehavior: Clip.antiAlias,
+          child: InkWell(
+            onTap: () async {
+              final archiveService = context.read<ArchiveService>();
 
-            try {
-              // Show loading indicator
-              if (context.mounted) {
-                ScaffoldMessenger.of(context).showSnackBar(
-                  SnackBar(
-                    content: Text('Loading ${result.title}...'),
-                    duration: const Duration(seconds: 1),
+              try {
+                // Show loading indicator
+                if (context.mounted) {
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    SnackBar(
+                      content: Text('Loading ${result.title}...'),
+                      duration: const Duration(seconds: 1),
+                    ),
+                  );
+                }
+
+                // Fetch metadata for the archive
+                await archiveService.fetchMetadata(result.identifier);
+
+                if (!context.mounted) return;
+
+                // Navigate to detail screen with MD3 fadeThrough transition
+                await Navigator.push(
+                  context,
+                  MD3PageTransitions.fadeThrough(
+                    page: const ArchiveDetailScreen(),
+                    settings: const RouteSettings(name: '/archive-detail'),
                   ),
                 );
+              } on FormatException catch (e) {
+                if (!context.mounted) return;
+                SnackBarHelper.showError(
+                  context,
+                  'Invalid archive: ${e.message}',
+                );
+              } catch (e) {
+                if (!context.mounted) return;
+
+                // Provide more specific error messages
+                String errorMessage = 'Could not open archive';
+                if (e.toString().contains('404') ||
+                    e.toString().contains('not found')) {
+                  errorMessage = 'Archive "${result.identifier}" not found';
+                } else if (e.toString().contains('timeout')) {
+                  errorMessage = 'Request timed out. Please try again.';
+                } else if (e.toString().contains('network')) {
+                  errorMessage = 'Network error. Check your connection.';
+                }
+
+                SnackBarHelper.showError(context, errorMessage);
               }
-
-              // Fetch metadata for the archive
-              await archiveService.fetchMetadata(result.identifier);
-
-              if (!context.mounted) return;
-
-              // Navigate to detail screen with MD3 fadeThrough transition
-              await Navigator.push(
-                context,
-                MD3PageTransitions.fadeThrough(
-                  page: const ArchiveDetailScreen(),
-                  settings: const RouteSettings(name: '/archive-detail'),
-                ),
-              );
-            } on FormatException catch (e) {
-              if (!context.mounted) return;
-              SnackBarHelper.showError(
-                context,
-                'Invalid archive: ${e.message}',
-              );
-            } catch (e) {
-              if (!context.mounted) return;
-
-              // Provide more specific error messages
-              String errorMessage = 'Could not open archive';
-              if (e.toString().contains('404') ||
-                  e.toString().contains('not found')) {
-                errorMessage = 'Archive "${result.identifier}" not found';
-              } else if (e.toString().contains('timeout')) {
-                errorMessage = 'Request timed out. Please try again.';
-              } else if (e.toString().contains('network')) {
-                errorMessage = 'Network error. Check your connection.';
-              }
-
-              SnackBarHelper.showError(context, errorMessage);
-            }
-          },
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              // Thumbnail image with fallback
-              Expanded(
-                child: result.thumbnailUrl != null
-                    ? CachedNetworkImage(
-                        imageUrl: result.thumbnailUrl!,
-                        fit: BoxFit.cover,
-                        width: double.infinity,
-                        placeholder: (context, url) => Container(
-                          color: colorScheme.surfaceContainerHighest,
-                          child: Center(
-                            child: CircularProgressIndicator(
-                              strokeWidth: 2,
+            },
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                // Thumbnail image with fallback
+                Expanded(
+                  child: result.thumbnailUrl != null
+                      ? CachedNetworkImage(
+                          imageUrl: result.thumbnailUrl!,
+                          fit: BoxFit.cover,
+                          width: double.infinity,
+                          placeholder: (context, url) => Container(
+                            color: colorScheme.surfaceContainerHighest,
+                            child: Center(
+                              child: CircularProgressIndicator(
+                                strokeWidth: 2,
+                                color: colorScheme.primary,
+                              ),
+                            ),
+                          ),
+                          errorWidget: (context, url, error) => Container(
+                            color: colorScheme.surfaceContainerHighest,
+                            child: Icon(
+                              Icons.inventory_2,
+                              size: 48,
                               color: colorScheme.primary,
                             ),
                           ),
-                        ),
-                        errorWidget: (context, url, error) => Container(
+                        )
+                      : Container(
+                          width: double.infinity,
                           color: colorScheme.surfaceContainerHighest,
                           child: Icon(
                             Icons.inventory_2,
@@ -699,46 +712,37 @@ class _TrendingCard extends StatelessWidget {
                             color: colorScheme.primary,
                           ),
                         ),
-                      )
-                    : Container(
-                        width: double.infinity,
-                        color: colorScheme.surfaceContainerHighest,
-                        child: Icon(
-                          Icons.inventory_2,
-                          size: 48,
-                          color: colorScheme.primary,
-                        ),
-                      ),
-              ),
-              // Title and description
-              Padding(
-                padding: const EdgeInsets.all(8.0),
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Text(
-                      result.title,
-                      style: theme.textTheme.bodySmall?.copyWith(
-                        fontWeight: FontWeight.w600,
-                      ),
-                      maxLines: 2,
-                      overflow: TextOverflow.ellipsis,
-                    ),
-                    if (result.description.isNotEmpty) ...[
-                      const SizedBox(height: 2),
+                ),
+                // Title and description
+                Padding(
+                  padding: const EdgeInsets.all(8.0),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
                       Text(
-                        result.description,
-                        style: theme.textTheme.labelSmall?.copyWith(
-                          color: colorScheme.onSurfaceVariant,
+                        result.title,
+                        style: theme.textTheme.bodySmall?.copyWith(
+                          fontWeight: FontWeight.w600,
                         ),
                         maxLines: 2,
                         overflow: TextOverflow.ellipsis,
                       ),
+                      if (result.description.isNotEmpty) ...[
+                        const SizedBox(height: 2),
+                        Text(
+                          result.description,
+                          style: theme.textTheme.labelSmall?.copyWith(
+                            color: colorScheme.onSurfaceVariant,
+                          ),
+                          maxLines: 2,
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                      ],
                     ],
-                  ],
+                  ),
                 ),
-              ),
-            ],
+              ],
+            ),
           ),
         ),
       ),

--- a/lib/screens/library_screen.dart
+++ b/lib/screens/library_screen.dart
@@ -754,77 +754,84 @@ class _LibraryScreenState extends State<LibraryScreen>
     return Semantics(
       button: true,
       label: 'Collection: ${collection.name}, $itemCount items',
-      child: Card(
-        margin: const EdgeInsets.only(bottom: 12),
-        child: InkWell(
-          onTap: () => _openCollection(collection),
-          borderRadius: BorderRadius.circular(12),
-          child: Padding(
-            padding: const EdgeInsets.all(16),
-            child: Row(
-              children: [
-                // Collection icon
-                Container(
-                  width: 56,
-                  height: 56,
-                  decoration: BoxDecoration(
-                    color: collection.color ?? colorScheme.primaryContainer,
-                    borderRadius: BorderRadius.circular(12),
+      child: Tooltip(
+        excludeFromSemantics: true,
+        message: 'Open collection ${collection.name}',
+        child: Card(
+          margin: const EdgeInsets.only(bottom: 12),
+          child: InkWell(
+            onTap: () => _openCollection(collection),
+            borderRadius: BorderRadius.circular(12),
+            child: Padding(
+              padding: const EdgeInsets.all(16),
+              child: Row(
+                children: [
+                  // Collection icon
+                  Container(
+                    width: 56,
+                    height: 56,
+                    decoration: BoxDecoration(
+                      color: collection.color ?? colorScheme.primaryContainer,
+                      borderRadius: BorderRadius.circular(12),
+                    ),
+                    child: Icon(
+                      collection.iconData,
+                      color: collection.color != null
+                          ? _getContrastColor(collection.color!)
+                          : colorScheme.onPrimaryContainer,
+                      size: 28,
+                    ),
                   ),
-                  child: Icon(
-                    collection.iconData,
-                    color: collection.color != null
-                        ? _getContrastColor(collection.color!)
-                        : colorScheme.onPrimaryContainer,
-                    size: 28,
-                  ),
-                ),
-                const SizedBox(width: 16),
-                // Collection info
-                Expanded(
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      Text(
-                        collection.name,
-                        style: theme.textTheme.titleMedium,
-                        maxLines: 1,
-                        overflow: TextOverflow.ellipsis,
-                      ),
-                      if (collection.description != null &&
-                          collection.description!.isNotEmpty) ...[
-                        const SizedBox(height: 4),
+                  const SizedBox(width: 16),
+                  // Collection info
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
                         Text(
-                          collection.description!,
-                          style: theme.textTheme.bodySmall?.copyWith(
-                            color: colorScheme.onSurfaceVariant,
-                          ),
+                          collection.name,
+                          style: theme.textTheme.titleMedium,
                           maxLines: 1,
                           overflow: TextOverflow.ellipsis,
                         ),
-                      ],
-                      const SizedBox(height: 8),
-                      Row(
-                        children: [
-                          Icon(
-                            Icons.inventory_2_outlined,
-                            size: 14,
-                            color: colorScheme.onSurfaceVariant,
-                          ),
-                          const SizedBox(width: 4),
+                        if (collection.description != null &&
+                            collection.description!.isNotEmpty) ...[
+                          const SizedBox(height: 4),
                           Text(
-                            '$itemCount ${itemCount == 1 ? 'item' : 'items'}',
-                            style: theme.textTheme.labelSmall?.copyWith(
+                            collection.description!,
+                            style: theme.textTheme.bodySmall?.copyWith(
                               color: colorScheme.onSurfaceVariant,
                             ),
+                            maxLines: 1,
+                            overflow: TextOverflow.ellipsis,
                           ),
                         ],
-                      ),
-                    ],
+                        const SizedBox(height: 8),
+                        Row(
+                          children: [
+                            Icon(
+                              Icons.inventory_2_outlined,
+                              size: 14,
+                              color: colorScheme.onSurfaceVariant,
+                            ),
+                            const SizedBox(width: 4),
+                            Text(
+                              '$itemCount ${itemCount == 1 ? 'item' : 'items'}',
+                              style: theme.textTheme.labelSmall?.copyWith(
+                                color: colorScheme.onSurfaceVariant,
+                              ),
+                            ),
+                          ],
+                        ),
+                      ],
+                    ),
                   ),
-                ),
-                Icon(Icons.chevron_right, color: colorScheme.onSurfaceVariant),
-              ],
+                  Icon(
+                    Icons.chevron_right,
+                    color: colorScheme.onSurfaceVariant,
+                  ),
+                ],
+              ),
             ),
           ),
         ),
@@ -841,61 +848,65 @@ class _LibraryScreenState extends State<LibraryScreen>
     return Semantics(
       button: true,
       label: 'Collection: ${collection.name}, $itemCount items',
-      child: Card(
-        child: InkWell(
-          onTap: () => _openCollection(collection),
-          borderRadius: BorderRadius.circular(12),
-          child: Padding(
-            padding: const EdgeInsets.all(16),
-            child: Column(
-              mainAxisAlignment: MainAxisAlignment.center,
-              crossAxisAlignment: CrossAxisAlignment.center,
-              children: [
-                // Collection icon (larger for grid)
-                Container(
-                  width: 64,
-                  height: 64,
-                  decoration: BoxDecoration(
-                    color: collection.color ?? colorScheme.primaryContainer,
-                    borderRadius: BorderRadius.circular(16),
-                  ),
-                  child: Icon(
-                    collection.iconData,
-                    color: collection.color != null
-                        ? _getContrastColor(collection.color!)
-                        : colorScheme.onPrimaryContainer,
-                    size: 32,
-                  ),
-                ),
-                const SizedBox(height: 12),
-                // Collection name
-                Text(
-                  collection.name,
-                  style: theme.textTheme.titleMedium,
-                  maxLines: 2,
-                  overflow: TextOverflow.ellipsis,
-                  textAlign: TextAlign.center,
-                ),
-                const SizedBox(height: 4),
-                // Item count
-                Row(
-                  mainAxisAlignment: MainAxisAlignment.center,
-                  children: [
-                    Icon(
-                      Icons.inventory_2_outlined,
-                      size: 14,
-                      color: colorScheme.onSurfaceVariant,
+      child: Tooltip(
+        excludeFromSemantics: true,
+        message: 'Open collection ${collection.name}',
+        child: Card(
+          child: InkWell(
+            onTap: () => _openCollection(collection),
+            borderRadius: BorderRadius.circular(12),
+            child: Padding(
+              padding: const EdgeInsets.all(16),
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                crossAxisAlignment: CrossAxisAlignment.center,
+                children: [
+                  // Collection icon (larger for grid)
+                  Container(
+                    width: 64,
+                    height: 64,
+                    decoration: BoxDecoration(
+                      color: collection.color ?? colorScheme.primaryContainer,
+                      borderRadius: BorderRadius.circular(16),
                     ),
-                    const SizedBox(width: 4),
-                    Text(
-                      '$itemCount ${itemCount == 1 ? 'item' : 'items'}',
-                      style: theme.textTheme.labelSmall?.copyWith(
+                    child: Icon(
+                      collection.iconData,
+                      color: collection.color != null
+                          ? _getContrastColor(collection.color!)
+                          : colorScheme.onPrimaryContainer,
+                      size: 32,
+                    ),
+                  ),
+                  const SizedBox(height: 12),
+                  // Collection name
+                  Text(
+                    collection.name,
+                    style: theme.textTheme.titleMedium,
+                    maxLines: 2,
+                    overflow: TextOverflow.ellipsis,
+                    textAlign: TextAlign.center,
+                  ),
+                  const SizedBox(height: 4),
+                  // Item count
+                  Row(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      Icon(
+                        Icons.inventory_2_outlined,
+                        size: 14,
                         color: colorScheme.onSurfaceVariant,
                       ),
-                    ),
-                  ],
-                ),
-              ],
+                      const SizedBox(width: 4),
+                      Text(
+                        '$itemCount ${itemCount == 1 ? 'item' : 'items'}',
+                        style: theme.textTheme.labelSmall?.copyWith(
+                          color: colorScheme.onSurfaceVariant,
+                        ),
+                      ),
+                    ],
+                  ),
+                ],
+              ),
             ),
           ),
         ),


### PR DESCRIPTION
💡 What: Added `Tooltip(excludeFromSemantics: true)` wrappers to the interactive `Card` widgets in the `DiscoverScreen` (Trending Card) and `LibraryScreen` (Collection Card).

🎯 Why: To provide helpful hover context for desktop/web users and long-press tooltips for mobile users without duplicating the screen reader announcements (which are handled by the existing `Semantics` wrapper).

♿ Accessibility: The addition of `excludeFromSemantics: true` ensures that screen readers do not redundantly read out the tooltip message alongside the existing `Semantics` label, while still displaying visual hover tooltips for sighted users.

---
*PR created automatically by Jules for task [6828284988820959033](https://jules.google.com/task/6828284988820959033) started by @Gameaday*