### PR TITLE
🎨 Palette: Improve accessibility for interactive rows in About and Help screens

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -86,3 +86,7 @@
 ## 2026-06-05 - Avoid polluting repository with scratchpad scripts
 **Learning:** Including ad-hoc scripts (like python parsers) created during codebase exploration and problem solving in the final commit pollutes the repository and degrades maintainability. They should be deleted before submitting.
 **Action:** Remember to delete local scratchpad scripts used for text operations before finishing tasks and completing pre-commit steps.
+
+## 2024-05-18 - Missing Accessibility on Helper Rows
+**Learning:** List items like credit rows or external links built using a base `InkWell` often miss out on standard button semantics, making them opaque to screen readers despite being interactive.
+**Action:** Always wrap custom interactive text rows (`InkWell`/`GestureDetector`) in `Semantics(button: true)` and `Tooltip(excludeFromSemantics: true)` if they behave as buttons or links.

--- a/lib/screens/about_screen.dart
+++ b/lib/screens/about_screen.dart
@@ -305,7 +305,10 @@ class _AboutScreenState extends State<AboutScreen> {
     String value, {
     VoidCallback? onTap,
   }) {
-    return InkWell(
+    final semanticLabel = onTap != null ? 'Open $label details' : label;
+    final tooltipMessage = onTap != null ? 'Open $label details' : '';
+
+    Widget content = InkWell(
       onTap: onTap,
       borderRadius: BorderRadius.circular(8),
       child: Padding(
@@ -337,6 +340,20 @@ class _AboutScreenState extends State<AboutScreen> {
         ),
       ),
     );
+
+    if (onTap != null) {
+      return Semantics(
+        button: true,
+        label: semanticLabel,
+        child: Tooltip(
+          excludeFromSemantics: true,
+          message: tooltipMessage,
+          child: content,
+        ),
+      );
+    }
+
+    return content;
   }
 
   Widget _buildFooter(BuildContext context) {

--- a/lib/screens/help_screen.dart
+++ b/lib/screens/help_screen.dart
@@ -332,32 +332,40 @@ class HelpScreen extends StatelessWidget {
   ) {
     return Padding(
       padding: const EdgeInsets.only(bottom: 12),
-      child: InkWell(
-        onTap: () => _launchUrl(url),
-        borderRadius: BorderRadius.circular(8),
-        child: Padding(
-          padding: const EdgeInsets.all(8),
-          child: Row(
-            children: [
-              Icon(icon, color: Theme.of(context).colorScheme.primary),
-              const SizedBox(width: 12),
-              Expanded(
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Text(
-                      title,
-                      style: const TextStyle(fontWeight: FontWeight.w500),
+      child: Semantics(
+        button: true,
+        label: 'Open $title link',
+        child: Tooltip(
+          excludeFromSemantics: true,
+          message: 'Open $title link',
+          child: InkWell(
+            onTap: () => _launchUrl(url),
+            borderRadius: BorderRadius.circular(8),
+            child: Padding(
+              padding: const EdgeInsets.all(8),
+              child: Row(
+                children: [
+                  Icon(icon, color: Theme.of(context).colorScheme.primary),
+                  const SizedBox(width: 12),
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          title,
+                          style: const TextStyle(fontWeight: FontWeight.w500),
+                        ),
+                        Text(
+                          description,
+                          style: Theme.of(context).textTheme.bodySmall,
+                        ),
+                      ],
                     ),
-                    Text(
-                      description,
-                      style: Theme.of(context).textTheme.bodySmall,
-                    ),
-                  ],
-                ),
+                  ),
+                  const Icon(Icons.open_in_new, size: 16),
+                ],
               ),
-              const Icon(Icons.open_in_new, size: 16),
-            ],
+            ),
           ),
         ),
       ),


### PR DESCRIPTION
💡 What: Wrapped the interactive `InkWell` components in `lib/screens/about_screen.dart` and `lib/screens/help_screen.dart` with `Semantics` and `Tooltip` widgets.
🎯 Why: These rows function as buttons/links but lacked proper semantic labels for screen readers and tooltips for desktop/web hover states, hurting accessibility.
📸 Before/After: Visuals remain unchanged; hover states and screen reader readouts are added.
♿ Accessibility: Screen readers will now correctly announce these items as actionable buttons (e.g., "Open Flutter details link, button"). Used `excludeFromSemantics: true` on the `Tooltip` to prevent redundant readouts.

---
*PR created automatically by Jules for task [14396011570080900316](https://jules.google.com/task/14396011570080900316) started by @Gameaday*